### PR TITLE
💄 Design : 사용자 마이페이지 메인 화면 디자인 #6

### DIFF
--- a/src/layouts/HeaderNoTitle.tsx
+++ b/src/layouts/HeaderNoTitle.tsx
@@ -3,7 +3,7 @@ import { PiBellSimpleBold } from 'react-icons/pi';
 
 const HeaderNoTitle = () => {
   return (
-    <div className='fixed top-0 flex h-[93px] w-[375px] flex-col items-center bg-white'>
+    <div className='fixed top-0 z-[1000] flex h-[93px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] flex h-[37px] w-[330px] items-center justify-between'>
         <img
           className='h-[15px] w-[50px]'

--- a/src/layouts/HeaderOnlyTitle.tsx
+++ b/src/layouts/HeaderOnlyTitle.tsx
@@ -2,7 +2,7 @@ import { TitleProps } from './HeaderWithTitle';
 
 const HeaderOnlyTitle = ({ title }: TitleProps) => {
   return (
-    <div className='fixed top-0 flex h-[93px] w-[375px] flex-col items-center bg-white'>
+    <div className='fixed top-0 z-[1000] flex h-[93px] w-[375px] flex-col items-center bg-white'>
       <p className='fixed top-[46px] flex h-[42px] flex-col items-center justify-center text-[18px] font-medium'>
         {title}
       </p>

--- a/src/layouts/HeaderWithTitle.tsx
+++ b/src/layouts/HeaderWithTitle.tsx
@@ -7,7 +7,7 @@ export interface TitleProps {
 
 const HeaderWithTitle = ({ title }: TitleProps) => {
   return (
-    <div className='fixed top-0 flex h-[132px] w-[375px] flex-col items-center bg-white'>
+    <div className='fixed top-0 z-[1000] flex h-[132px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] w-[330px] flex-col'>
         <div className='flex h-[37px] w-[100%] items-center justify-between'>
           <img

--- a/src/pages/UserMypage/components/CategoryButton.tsx
+++ b/src/pages/UserMypage/components/CategoryButton.tsx
@@ -1,0 +1,19 @@
+import { MdArrowForwardIos } from 'react-icons/md';
+
+interface CategoryProps {
+  category: string;
+}
+
+const CategoryButton = ({ category }: CategoryProps) => {
+  return (
+    <button
+      type='button'
+      className='flex h-[49px] items-center justify-between rounded-[10px] bg-white px-[14px] py-[9px] text-[14px] font-medium shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+    >
+      {category}
+      <MdArrowForwardIos />
+    </button>
+  );
+};
+
+export default CategoryButton;

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -1,0 +1,62 @@
+interface Reservation {
+  name: string;
+  date: string;
+  time: string;
+  room: string;
+  people: number;
+  price: number;
+}
+
+const latestReservationCard: Reservation = {
+  name: 'ABC스터디룸',
+  date: '2024.06.08',
+  time: '14:00',
+  room: 'ROOM A',
+  people: 4,
+  price: 8000,
+};
+
+const LatestReservation = () => {
+  return (
+    <div className='flex h-auto w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
+      <div className='flex items-center gap-[18px]'>
+        <img
+          src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg'
+          alt='스터디룸 사진'
+          className='h-[118px] w-[118px] object-cover'
+        />
+
+        <div className='flex w-[auto] flex-col gap-[7px]'>
+          <p className='text-[16px] font-semibold'>
+            {latestReservationCard.name}
+          </p>
+          <ul className='flex flex-col gap-[2px] text-[12px]'>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약일</p>
+              <span className='font-medium'>{latestReservationCard.date}</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약시간</p>
+              <span className='font-medium'>{latestReservationCard.time}</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약된 룸</p>
+              <span className='font-medium'>{latestReservationCard.room}</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>인원</p>
+              <span className='font-medium'>
+                {latestReservationCard.people}인
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <span className='self-end text-[14px] font-medium'>
+        {latestReservationCard.price}원
+      </span>
+    </div>
+  );
+};
+
+export default LatestReservation;

--- a/src/pages/UserMypage/index.tsx
+++ b/src/pages/UserMypage/index.tsx
@@ -1,0 +1,54 @@
+import HeaderNoTitle from '@layouts/HeaderNoTitle';
+import MainLayout from '@layouts/MainLayout';
+import BottomNavigation from '@layouts/BottomNavigation';
+import { MdArrowForwardIos } from 'react-icons/md';
+import LatestReservation from './components/LatestReservation';
+import CategoryButton from './components/CategoryButton';
+
+const user = {
+  name: 'HYUN',
+  email: 'hyun@gmail.com',
+};
+
+const UserMypage = () => {
+  return (
+    <>
+      <MainLayout>
+        <HeaderNoTitle />
+
+        <div className='flex h-[263px] w-[375px] flex-col items-center bg-primary'>
+          <div className='self-start pl-[33px] pt-[30px]'>
+            <div className='text-[32px] font-bold leading-none text-white'>
+              {user.name}
+            </div>
+            <div className='pt-0 text-[14px] text-white'>{user.email}</div>
+          </div>
+          <div className='absolute top-[255px] flex w-[330px] flex-col gap-[18px]'>
+            <div className='flex flex-col gap-[10px]'>
+              <button
+                type='button'
+                className='flex items-center gap-[2px] self-end text-[14px] text-white'
+              >
+                예약 내역
+                <MdArrowForwardIos />
+              </button>
+              <LatestReservation />
+            </div>
+            <CategoryButton category='리뷰 관리' />
+            <CategoryButton category='회원 정보' />
+            <button
+              type='button'
+              className='h-[25px] self-start text-[12px] text-subfont underline'
+            >
+              로그아웃
+            </button>
+          </div>
+        </div>
+
+        <BottomNavigation />
+      </MainLayout>
+    </>
+  );
+};
+
+export default UserMypage;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,3 +1,4 @@
+import UserMypage from '@pages/UserMypage';
 import { createBrowserRouter } from 'react-router-dom';
 
 const router = createBrowserRouter([
@@ -15,7 +16,15 @@ const router = createBrowserRouter([
   },
   {
     path: '/user-page',
-    // element: <MyPage />,
+    element: <UserMypage />,
+  },
+  {
+    path: '/reservation-page',
+    // element:
+  },
+  {
+    path: '/host-page',
+    // element:
   },
   {
     path: '*',


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사용자 마이페이지 기초 마크업 구현

## 📝 요구 사항과 구현 내용
- 사용자 마이페이지 라우터 연결
- 사용자 마이페이지 마크업 틀 작성
  - 가장 최근 결제 내역을 보여줄 카드 컴포넌트 생성
  - 리뷰 페이지와 회원 정보 조회 페이지로 이동할 컴포넌트 생성
- 공통 레이아웃 헤더에 z-index 추가
- 라우터에 호스트 마이페이지, 예약 내역 페이지 추가

## 💬 PR 포인트 & 궁금한 점
- 추후 수정될 수 있습니다!