### PR TITLE
💄 Design : 사업자 마이페이지 메인화면 마크업 구현

### DIFF
--- a/src/layouts/HeaderNoTitle.tsx
+++ b/src/layouts/HeaderNoTitle.tsx
@@ -1,5 +1,5 @@
 import Logo from '@assets/images/roomit_logo.png';
-import { PiBellSimpleBold } from 'react-icons/pi';
+import { RiNotification3Line } from 'react-icons/ri';
 
 const HeaderNoTitle = () => {
   return (
@@ -10,7 +10,7 @@ const HeaderNoTitle = () => {
           src={Logo}
           alt='ROOM:IT 로고'
         />
-        <PiBellSimpleBold className='h-[24px] w-[24px]' />
+        <RiNotification3Line className='h-[24px] w-[24px]' />
       </div>
     </div>
   );

--- a/src/layouts/HeaderOnlyTitle.tsx
+++ b/src/layouts/HeaderOnlyTitle.tsx
@@ -3,7 +3,7 @@ import { TitleProps } from './HeaderWithTitle';
 const HeaderOnlyTitle = ({ title }: TitleProps) => {
   return (
     <div className='fixed top-0 z-[1000] flex h-[93px] w-[375px] flex-col items-center bg-white'>
-      <p className='fixed top-[46px] flex h-[42px] flex-col items-center justify-center text-[18px] font-medium'>
+      <p className='fixed top-[46px] flex h-[42px] flex-col items-center justify-center text-[18px] font-normal'>
         {title}
       </p>
     </div>

--- a/src/layouts/HeaderWithTitle.tsx
+++ b/src/layouts/HeaderWithTitle.tsx
@@ -1,5 +1,5 @@
 import Logo from '@assets/images/roomit_logo.png';
-import { AiOutlineBell } from 'react-icons/ai';
+import { RiNotification3Line } from 'react-icons/ri';
 
 export interface TitleProps {
   title: string;
@@ -15,9 +15,9 @@ const HeaderWithTitle = ({ title }: TitleProps) => {
             src={Logo}
             alt='ROOM:IT 로고'
           />
-          <AiOutlineBell className='h-[24px] w-[24px]' />
+          <RiNotification3Line className='h-[24px] w-[24px]' />
         </div>
-        <p className='flex h-[42px] w-[100%] items-center justify-center text-[18px] font-medium'>
+        <p className='flex h-[42px] w-[100%] items-center justify-center text-[18px] font-normal'>
           {title}
         </p>
       </div>

--- a/src/pages/HostMypage/components/HostButtonContainer.tsx
+++ b/src/pages/HostMypage/components/HostButtonContainer.tsx
@@ -1,0 +1,20 @@
+import CategoryButton from '@pages/UserMypage/components/CategoryButton';
+import HostCategoryButton from './HostCategoryButton';
+
+const HostButtonContainer = () => {
+  return (
+    <div className='absolute top-[290px] flex w-[330px] flex-col gap-[18px]'>
+      <HostCategoryButton category='예약자 확인' />
+      <HostCategoryButton category='사업장 관리' />
+      <CategoryButton category='회원 정보' />
+      <button
+        type='button'
+        className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+};
+
+export default HostButtonContainer;

--- a/src/pages/HostMypage/components/HostCategoryButton.tsx
+++ b/src/pages/HostMypage/components/HostCategoryButton.tsx
@@ -1,0 +1,20 @@
+import { CategoryProps } from '@pages/UserMypage/components/CategoryButton';
+import { RiGroupLine, RiCommunityLine } from 'react-icons/ri';
+
+const HostCategoryButton = ({ category }: CategoryProps) => {
+  return (
+    <button
+      type='button'
+      className='flex h-[136px] w-[330px] flex-col justify-end gap-[10px] rounded-[10px] bg-white px-[16px] py-[20px] text-[18px] font-normal shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+    >
+      {category === '예약자 확인' ? (
+        <RiGroupLine className='h-[30px] w-[30px] text-primary' />
+      ) : (
+        <RiCommunityLine className='h-[30px] w-[30px] text-primary' />
+      )}
+      {category}
+    </button>
+  );
+};
+
+export default HostCategoryButton;

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -1,0 +1,17 @@
+const host = {
+  name: 'HOST',
+  email: 'host@gmail.com',
+};
+
+const HostInfo = () => {
+  return (
+    <div className='self-start pl-[33px] pt-[30px]'>
+      <div className='text-[32px] font-bold leading-none text-white'>
+        {host.name}
+      </div>
+      <div className='pt-0 text-[14px] text-white'>{host.email}</div>
+    </div>
+  );
+};
+
+export default HostInfo;

--- a/src/pages/HostMypage/index.tsx
+++ b/src/pages/HostMypage/index.tsx
@@ -1,0 +1,40 @@
+import BottomNavigation from '@layouts/BottomNavigation';
+import HeaderNoTitle from '@layouts/HeaderNoTitle';
+import MainLayout from '@layouts/MainLayout';
+import CategoryButton from '../UserMypage/components/CategoryButton';
+import HostCategoryButton from './components/HostCategoryButton';
+
+const host = {
+  name: 'HOST',
+  email: 'host@gmail.com',
+};
+
+const HostMypage = () => {
+  return (
+    <MainLayout>
+      <HeaderNoTitle />
+      <div className='flex h-[263px] w-[375px] flex-col items-center bg-primary'>
+        <div className='self-start pl-[33px] pt-[30px]'>
+          <div className='text-[32px] font-bold leading-none text-white'>
+            {host.name}
+          </div>
+          <div className='pt-0 text-[14px] text-white'>{host.email}</div>
+        </div>
+        <div className='absolute top-[290px] flex w-[330px] flex-col gap-[18px]'>
+          <HostCategoryButton category='예약자 확인' />
+          <HostCategoryButton category='사업장 관리' />
+          <CategoryButton category='회원 정보' />
+          <button
+            type='button'
+            className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
+          >
+            로그아웃
+          </button>
+        </div>
+      </div>
+      <BottomNavigation />
+    </MainLayout>
+  );
+};
+
+export default HostMypage;

--- a/src/pages/HostMypage/index.tsx
+++ b/src/pages/HostMypage/index.tsx
@@ -1,36 +1,16 @@
 import BottomNavigation from '@layouts/BottomNavigation';
 import HeaderNoTitle from '@layouts/HeaderNoTitle';
 import MainLayout from '@layouts/MainLayout';
-import CategoryButton from '../UserMypage/components/CategoryButton';
-import HostCategoryButton from './components/HostCategoryButton';
-
-const host = {
-  name: 'HOST',
-  email: 'host@gmail.com',
-};
+import HostButtonContainer from './components/HostButtonContainer';
+import HostInfo from './components/HostInfo';
 
 const HostMypage = () => {
   return (
     <MainLayout>
       <HeaderNoTitle />
       <div className='flex h-[263px] w-[375px] flex-col items-center bg-primary'>
-        <div className='self-start pl-[33px] pt-[30px]'>
-          <div className='text-[32px] font-bold leading-none text-white'>
-            {host.name}
-          </div>
-          <div className='pt-0 text-[14px] text-white'>{host.email}</div>
-        </div>
-        <div className='absolute top-[290px] flex w-[330px] flex-col gap-[18px]'>
-          <HostCategoryButton category='예약자 확인' />
-          <HostCategoryButton category='사업장 관리' />
-          <CategoryButton category='회원 정보' />
-          <button
-            type='button'
-            className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
-          >
-            로그아웃
-          </button>
-        </div>
+        <HostInfo />
+        <HostButtonContainer />
       </div>
       <BottomNavigation />
     </MainLayout>

--- a/src/pages/UserMypage/components/CategoryButton.tsx
+++ b/src/pages/UserMypage/components/CategoryButton.tsx
@@ -1,6 +1,6 @@
 import { MdArrowForwardIos } from 'react-icons/md';
 
-interface CategoryProps {
+export interface CategoryProps {
   category: string;
 }
 
@@ -8,7 +8,7 @@ const CategoryButton = ({ category }: CategoryProps) => {
   return (
     <button
       type='button'
-      className='flex h-[49px] items-center justify-between rounded-[10px] bg-white px-[14px] py-[9px] text-[14px] font-medium shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+      className='flex h-[49px] items-center justify-between rounded-[10px] bg-white px-[16px] py-[9px] text-[14px] font-normal shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
     >
       {category}
       <MdArrowForwardIos />

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -27,32 +27,32 @@ const LatestReservation = () => {
         />
 
         <div className='flex w-[auto] flex-col gap-[7px]'>
-          <p className='text-[16px] font-semibold'>
+          <p className='text-[16px] font-medium'>
             {latestReservationCard.name}
           </p>
           <ul className='flex flex-col gap-[2px] text-[12px]'>
             <li className='flex gap-[12px]'>
               <p className='w-[46px]'>예약일</p>
-              <span className='font-medium'>{latestReservationCard.date}</span>
+              <span className='font-normal'>{latestReservationCard.date}</span>
             </li>
             <li className='flex gap-[12px]'>
               <p className='w-[46px]'>예약시간</p>
-              <span className='font-medium'>{latestReservationCard.time}</span>
+              <span className='font-normal'>{latestReservationCard.time}</span>
             </li>
             <li className='flex gap-[12px]'>
               <p className='w-[46px]'>예약된 룸</p>
-              <span className='font-medium'>{latestReservationCard.room}</span>
+              <span className='font-normal'>{latestReservationCard.room}</span>
             </li>
             <li className='flex gap-[12px]'>
               <p className='w-[46px]'>인원</p>
-              <span className='font-medium'>
+              <span className='font-normal'>
                 {latestReservationCard.people}인
               </span>
             </li>
           </ul>
         </div>
       </div>
-      <span className='self-end text-[14px] font-medium'>
+      <span className='self-end text-[14px] font-normal'>
         {latestReservationCard.price}원
       </span>
     </div>

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -1,0 +1,30 @@
+import { MdArrowForwardIos } from 'react-icons/md';
+import LatestReservation from './LatestReservation';
+import CategoryButton from './CategoryButton';
+
+const UserButtonContainer = () => {
+  return (
+    <div className='absolute top-[255px] flex w-[330px] flex-col gap-[18px]'>
+      <div className='flex flex-col gap-[10px]'>
+        <button
+          type='button'
+          className='flex items-center gap-[2px] self-end text-[14px] text-white'
+        >
+          예약 내역
+          <MdArrowForwardIos />
+        </button>
+        <LatestReservation />
+      </div>
+      <CategoryButton category='리뷰 관리' />
+      <CategoryButton category='회원 정보' />
+      <button
+        type='button'
+        className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+};
+
+export default UserButtonContainer;

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -1,0 +1,17 @@
+const user = {
+  name: 'HYUN',
+  email: 'hyun@gmail.com',
+};
+
+const UserInfo = () => {
+  return (
+    <div className='self-start pl-[33px] pt-[30px]'>
+      <div className='text-[32px] font-semibold leading-none text-white'>
+        {user.name}
+      </div>
+      <div className='pt-0 text-[14px] text-white'>{user.email}</div>
+    </div>
+  );
+};
+
+export default UserInfo;

--- a/src/pages/UserMypage/index.tsx
+++ b/src/pages/UserMypage/index.tsx
@@ -1,50 +1,18 @@
 import HeaderNoTitle from '@layouts/HeaderNoTitle';
 import MainLayout from '@layouts/MainLayout';
 import BottomNavigation from '@layouts/BottomNavigation';
-import { MdArrowForwardIos } from 'react-icons/md';
-import LatestReservation from './components/LatestReservation';
-import CategoryButton from './components/CategoryButton';
-
-const user = {
-  name: 'HYUN',
-  email: 'hyun@gmail.com',
-};
+import UserButtonContainer from './components/UserButtonContainer';
+import UserInfo from './components/UserInfo';
 
 const UserMypage = () => {
   return (
     <>
       <MainLayout>
         <HeaderNoTitle />
-
         <div className='flex h-[263px] w-[375px] flex-col items-center bg-primary'>
-          <div className='self-start pl-[33px] pt-[30px]'>
-            <div className='text-[32px] font-bold leading-none text-white'>
-              {user.name}
-            </div>
-            <div className='pt-0 text-[14px] text-white'>{user.email}</div>
-          </div>
-          <div className='absolute top-[255px] flex w-[330px] flex-col gap-[18px]'>
-            <div className='flex flex-col gap-[10px]'>
-              <button
-                type='button'
-                className='flex items-center gap-[2px] self-end text-[14px] text-white'
-              >
-                예약 내역
-                <MdArrowForwardIos />
-              </button>
-              <LatestReservation />
-            </div>
-            <CategoryButton category='리뷰 관리' />
-            <CategoryButton category='회원 정보' />
-            <button
-              type='button'
-              className='h-[25px] self-start text-[12px] text-subfont underline'
-            >
-              로그아웃
-            </button>
-          </div>
+          <UserInfo />
+          <UserButtonContainer />
         </div>
-
         <BottomNavigation />
       </MainLayout>
     </>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,4 +1,5 @@
 import MainPage from '@pages/MainPage';
+import HostMypage from '@pages/HostMypage';
 import UserMypage from '@pages/UserMypage';
 import { createBrowserRouter } from 'react-router-dom';
 import StartPage from '@pages/StartPage';
@@ -42,7 +43,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/host-page',
-    // element:
+    element: <HostMypage />,
   },
   {
     path: '*',


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업자 마이페이지 메인화면 마크업 구현
- 헤더 알림 아이콘 수정
- 폰트 사이즈 수정

## 📝 요구 사항과 구현 내용
- 사업자 마이페이지 메인화면 마크업 구현
- 사용자, 사업자 마이페이지 index.tsx 파일 수정
- 폰트 사이즈 변경
- 헤더 알림 아이콘 및 제목 폰트 사이즈 수정

## ✅ 피드백 반영사항
- index.tsx 파일을 간결하게 수정했습니다.

## 💬 PR 포인트 & 궁금한 점
- 리액트 아이콘에 동일한 알림 아이콘이 있길래 그걸로 바꿔놨습니다!