### PR TITLE
💄 Design : 예약 내역 페이지 마크업 구현 #18

### DIFF
--- a/src/components/ButtonInCard.tsx
+++ b/src/components/ButtonInCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ButtonInCardProps {
+  name: string;
+  onClickFunction?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const ButtonInCard = ({ name, onClickFunction }: ButtonInCardProps) => {
+  return (
+    <button
+      type='button'
+      className='card-button'
+      onClick={onClickFunction}
+    >
+      {name}
+    </button>
+  );
+};
+
+export default ButtonInCard;

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,12 @@
+const LogoutButton = () => {
+  return (
+    <button
+      type='button'
+      className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
+    >
+      로그아웃
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@
   .main-textarea {
     @apply w-custom resize-none rounded-[8px] border border-solid border-subfont p-[14px] focus:border-focusColor focus:outline-none;
   }
+
+  .card-button {
+    @apply h-[34px] w-[76px] border-[0.5px] border-solid border-subfont text-[12px] active:bg-subfont active:bg-opacity-50;
+  }
 }
 
 @layer utilities {

--- a/src/pages/HostMypage/components/HostButtonContainer.tsx
+++ b/src/pages/HostMypage/components/HostButtonContainer.tsx
@@ -1,4 +1,5 @@
 import CategoryButton from '@pages/UserMypage/components/CategoryButton';
+import LogoutButton from '@components/LogoutButton';
 import HostCategoryButton from './HostCategoryButton';
 
 const HostButtonContainer = () => {
@@ -7,12 +8,7 @@ const HostButtonContainer = () => {
       <HostCategoryButton category='예약자 확인' />
       <HostCategoryButton category='사업장 관리' />
       <CategoryButton category='회원 정보' />
-      <button
-        type='button'
-        className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
-      >
-        로그아웃
-      </button>
+      <LogoutButton />
     </div>
   );
 };

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -1,0 +1,124 @@
+import ButtonInCard from '@components/ButtonInCard';
+import { Reservation } from '@pages/WriteReviewPage/components/ReservationInfo';
+import { useNavigate } from 'react-router-dom';
+
+const ReservationDetailCard = ({ item }: { item: Reservation }) => {
+  const { name, date, time, endtime, room, people, price, img, createdAt } =
+    item;
+  const navigate = useNavigate();
+
+  const now = new Date();
+  const gap = +new Date(time) - +now;
+
+  // LocalDatetime에서 시간(HH:mm) 추출
+  const getTimeFunction = (timeString: string) => {
+    const hour = new Date(timeString).getHours().toString().padStart(2, '0');
+    const minutes = new Date(timeString)
+      .getMinutes()
+      .toString()
+      .padStart(2, '0');
+    const reservationTime = `${hour}:${minutes}`;
+
+    return reservationTime;
+  };
+
+  // LocalDatetime에서 날짜(년, 월, 일) 추출
+  const getDateFunction = (timeString: string) => {
+    const year = new Date(timeString).getFullYear();
+    const month = (new Date(timeString).getMonth() + 1)
+      .toString()
+      .padStart(2, '0');
+    const day = new Date(timeString).getDate().toString().padStart(2, '0');
+    const payDay = `${year}.${month}.${day}`;
+
+    return payDay;
+  };
+
+  // 예약 시간으로부터 24시간 전인지 확인
+  const buttonType = (timeGap: number): string => {
+    let buttonText = '';
+    const MILLISECONDS_24_HOURS = 24 * 60 * 60 * 1000;
+
+    // 예약시간 24시간 전까지는 결제 취소 버튼
+    if (timeGap > MILLISECONDS_24_HOURS) {
+      buttonText = 'cancelPayment';
+    }
+    // 예약 시간 전 하루(24시간)동안은 버튼 없음
+    if (timeGap > 0 && timeGap <= MILLISECONDS_24_HOURS) {
+      buttonText = 'none';
+    }
+    // 예약 시간 지나면 리뷰 작성 버튼
+    if (timeGap < 0) {
+      buttonText = 'review';
+    }
+
+    return buttonText;
+  };
+
+  const handleReviewButton = () => {
+    navigate('/write-review');
+  };
+
+  return (
+    <div className='mx-auto flex w-custom flex-col gap-[18px] border-b border-solid border-b-black px-[13px] py-[24px]'>
+      <div className='flex items-center gap-[18px]'>
+        <img
+          src={img}
+          alt='스터디룸 사진'
+          className='h-[118px] w-[118px] object-cover'
+        />
+
+        <div className='flex w-[auto] flex-col gap-[7px]'>
+          <p className='text-[16px] font-medium'>{name}</p>
+          <ul className='flex flex-col gap-[2px] text-[12px]'>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약일</p>
+              <span className='font-normal'>{date}</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약시간</p>
+              <span className='font-normal'>
+                {getTimeFunction(time)} ~ {getTimeFunction(endtime as string)}
+              </span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>예약된 룸</p>
+              <span className='font-normal'>{room}</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>인원</p>
+              <span className='font-normal'>{people}인</span>
+            </li>
+            <li className='flex gap-[12px]'>
+              <p className='w-[46px]'>결제일</p>
+              <span className='font-normal'>
+                {getDateFunction(createdAt as string)}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className='flex items-center justify-between'>
+        {buttonType(gap) === 'cancelPayment' && (
+          <ButtonInCard name='결제 취소' />
+        )}
+        {buttonType(gap) === 'review' && (
+          <ButtonInCard
+            name='리뷰 작성'
+            onClickFunction={handleReviewButton}
+          />
+        )}
+        {buttonType(gap) === 'none' && (
+          <span className='text-[12px] text-primary'>
+            방문 24시간 전입니다.
+          </span>
+        )}
+        <span className='self-end text-[14px] font-normal'>
+          {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationDetailCard;

--- a/src/pages/ReservationListPage/components/ReservationList.tsx
+++ b/src/pages/ReservationListPage/components/ReservationList.tsx
@@ -1,0 +1,84 @@
+import { Reservation } from '@pages/WriteReviewPage/components/ReservationInfo';
+import ReservationDetailCard from './ReservationDetailCard';
+
+const reservationCardList: Reservation[] = [
+  {
+    roomId: 1,
+    name: 'ABC스터디룸',
+    date: '2024.06.08',
+    time: '2024-06-08T14:00:00',
+    endtime: '2024-06-08T16:00:00',
+    room: 'ROOM A',
+    people: 4,
+    price: 8000,
+    img: 'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
+    createdAt: '2024-06-07T12:42:11',
+  },
+  {
+    roomId: 2,
+    name: 'ㄱㄴㄷ스터디룸',
+    date: '2024.11.20',
+    time: '2024-11-20T12:00:00',
+    endtime: '2024-11-20T13:00:00',
+    room: '룸 1',
+    people: 3,
+    price: 4000,
+    img: 'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20231103_176%2F1698976078471RKtLE_JPEG%2FIMG_9223.jpeg',
+    createdAt: '2024-11-16T06:42:11',
+  },
+  {
+    roomId: 3,
+    name: '☆☆☆스터디룸',
+    date: '2024.11.30',
+    time: '2024-11-30T09:00:00',
+    endtime: '2024-11-30T12:00:00',
+    room: '룸 2',
+    people: 2,
+    price: 4000,
+    img: 'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230323_120%2F1679571970387BaDBd_JPEG%2F1679570041991-0.jpg',
+    createdAt: '2024-11-17T06:42:11',
+  },
+  {
+    roomId: 4,
+    name: '☆☆☆스터디룸',
+    date: '2024.11.21',
+    time: '2024-11-21T09:00:00',
+    endtime: '2024-11-21T16:00:00',
+    room: '룸 1',
+    people: 2,
+    price: 4000,
+    img: 'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230323_120%2F1679571970387BaDBd_JPEG%2F1679570041991-0.jpg',
+    createdAt: '2024-11-16T06:42:12',
+  },
+];
+
+const ReservationList = () => {
+  // 최근 결제 순으로 정렬
+  const sortedReservationList = [...reservationCardList].sort(
+    (b, a) =>
+      +new Date(a.createdAt as string) - +new Date(b.createdAt as string),
+  );
+
+  return (
+    <>
+      {reservationCardList.length > 0 ? (
+        <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
+          {sortedReservationList.map((item) => {
+            return (
+              <ReservationDetailCard
+                key={item.roomId}
+                item={item}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className='mt-[47px] w-[375px] text-center text-[14px] font-normal text-subfont'>
+          예약 내역이 없습니다.
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ReservationList;

--- a/src/pages/ReservationListPage/index.tsx
+++ b/src/pages/ReservationListPage/index.tsx
@@ -1,0 +1,14 @@
+import HeaderWithTitle from '@layouts/HeaderWithTitle';
+import MainLayout from '@layouts/MainLayout';
+import ReservationList from './components/ReservationList';
+
+const ReservationListPage = () => {
+  return (
+    <MainLayout headerType='both'>
+      <HeaderWithTitle title='예약 내역' />
+      <ReservationList />
+    </MainLayout>
+  );
+};
+
+export default ReservationListPage;

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -1,4 +1,5 @@
 import { MdArrowForwardIos } from 'react-icons/md';
+import LogoutButton from '@components/LogoutButton';
 import LatestReservation from './LatestReservation';
 import CategoryButton from './CategoryButton';
 
@@ -17,12 +18,7 @@ const UserButtonContainer = () => {
       </div>
       <CategoryButton category='리뷰 관리' />
       <CategoryButton category='회원 정보' />
-      <button
-        type='button'
-        className='h-[23px] self-start text-[12px] text-subfont underline active:text-black'
-      >
-        로그아웃
-      </button>
+      <LogoutButton />
     </div>
   );
 };

--- a/src/pages/WriteReviewPage/components/ReservationInfo.tsx
+++ b/src/pages/WriteReviewPage/components/ReservationInfo.tsx
@@ -1,10 +1,14 @@
-interface Reservation {
+export interface Reservation {
+  roomId?: number;
   name: string;
   date: string;
   time: string;
+  endtime?: string;
   room: string;
   people: number;
   price: number;
+  img?: string;
+  createdAt?: string;
 }
 
 const ReservationInfoData: Reservation = {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import UserSignUp from '@pages/UserSignUp';
 import BusinessLogin from '@pages/BusinessLogin';
 import BusinessSignUp from '@pages/BusinessSignUp';
 import WriteReviewPage from '@pages/WriteReviewPage';
+import ReservationListPage from '@pages/ReservationListPage';
 
 const router = createBrowserRouter([
   {
@@ -39,8 +40,8 @@ const router = createBrowserRouter([
     element: <UserMypage />,
   },
   {
-    path: '/reservation-page',
-    // element:
+    path: '/reservation-list',
+    element: <ReservationListPage />,
   },
   {
     path: '/write-review',


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 예약 내역 페이지 마크업 구현

## 📝 요구 사항과 구현 내용
- 예약 내역 페이지 마크업 구현
  - 24시간 전인지 확인하고 결제 취소, 리뷰 작성 버튼 다르게 보여주기
  - 24시간 이내에 방문 예정이면 '방문 24시간 전입니다' 문구 보여주기
  - 리뷰 작성 버튼과 리뷰 작성 페이지 연결
- 예약 내역 페이지 카드 안 버튼 나중에 여러 페이지에서 사용될 예정이라 공통 컴포넌트로 생성(src/components 폴더에 생성)
  - 해당 버튼 스타일 .card-button 이름으로 index.css에 추가

## ✅ 피드백 반영사항
- 유저 마이페이지, 호스트 마이페이지 로그아웃 버튼 컴포넌트 생성(src/components 폴더에 생성) 후 대체

## 💬 PR 포인트 & 궁금한 점
- 시간이 어떻게 올지 정확하게 몰라서 일차적으로 YYYY-MM-DDTHH:mm:ss 로 테스트 진행 후 마크업 구현했습니다. 나중에 기능 구현할 때 전체적으로 수정하겠습니다! 
- 결제 취소 버튼 눌렀을 때 확인하는 팝업을 띄워줘야 할 것 같습니다. 사업장 삭제 등에도 쓰일 것 같으니까 나중에 디자인에 팝업창 추가해두겠습니다..!