### PR TITLE
💄 Design, ✨ Feat : 사용자 알림 페이지 마크업 및 최근 7일 이내 알림 구분 기능 구현

### DIFF
--- a/src/components/ShowWithinSevenDays.tsx
+++ b/src/components/ShowWithinSevenDays.tsx
@@ -1,0 +1,14 @@
+interface TimeProps {
+  label: string;
+}
+
+const ShowWithinSevenDays = ({ label }: TimeProps) => {
+  return (
+    <div className='mx-auto flex w-custom items-center justify-between gap-4'>
+      <hr className='h-[0.5px] w-[calc(100%-50px)] border-0 bg-focusColor' />
+      <span className='w-[50px] text-xs text-focusColor'>{label}</span>
+    </div>
+  );
+};
+
+export default ShowWithinSevenDays;

--- a/src/pages/UserNotiPage/components/UserNotiCard.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiCard.tsx
@@ -1,0 +1,41 @@
+import { getDateFunction } from '@utils/formatTime';
+import { UserNotification } from './UserNotiList';
+
+const UpcomingNotiCard = ({ item }: { item: UserNotification }) => {
+  const { type, message, reservationInfo, createdAt, price } = item;
+
+  return (
+    <div className='mx-auto flex w-custom flex-col gap-3 px-1.5 py-[13px] text-sm'>
+      {type === 'upcoming' ? (
+        <p className='font-medium'>다가오는 일정</p>
+      ) : (
+        <p className='font-medium'>예약 완료</p>
+      )}
+
+      <div className='flex flex-col gap-1'>
+        <p className='text-xs text-subfont'>{getDateFunction(createdAt)}</p>
+        <div className='flex justify-between'>
+          {!price ? (
+            <div className='flex flex-col'>
+              <p>{message}</p>
+              <p>{reservationInfo}</p>
+            </div>
+          ) : (
+            <div className='flex flex-col'>
+              <p>{`${reservationInfo} 예약이 완료되었습니다.`}</p>
+              <p>{price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원</p>
+            </div>
+          )}
+
+          <img
+            src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg'
+            alt='스터디룸 사진'
+            className='h-10 w-10 object-cover'
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UpcomingNotiCard;

--- a/src/pages/UserNotiPage/components/UserNotiCard.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiCard.tsx
@@ -1,41 +1,45 @@
 import { getDateFunction } from '@utils/formatTime';
 import { UserNotification } from './UserNotiList';
 
-const UpcomingNotiCard = ({ item }: { item: UserNotification }) => {
+const UserNotiCard = ({ item }: { item: UserNotification }) => {
   const { type, message, reservationInfo, createdAt, price } = item;
 
   return (
-    <div className='mx-auto flex w-custom flex-col gap-3 px-1.5 py-[13px] text-sm'>
-      {type === 'upcoming' ? (
-        <p className='font-medium'>다가오는 일정</p>
-      ) : (
-        <p className='font-medium'>예약 완료</p>
-      )}
+    <>
+      <div className='mx-auto flex w-custom flex-col gap-3 px-1.5 py-[13px] text-sm'>
+        {type === 'upcoming' ? (
+          <p className='font-medium'>다가오는 일정</p>
+        ) : (
+          <p className='font-medium'>예약 완료</p>
+        )}
 
-      <div className='flex flex-col gap-1'>
-        <p className='text-xs text-subfont'>{getDateFunction(createdAt)}</p>
-        <div className='flex justify-between'>
-          {!price ? (
-            <div className='flex flex-col'>
-              <p>{message}</p>
-              <p>{reservationInfo}</p>
-            </div>
-          ) : (
-            <div className='flex flex-col'>
-              <p>{`${reservationInfo} 예약이 완료되었습니다.`}</p>
-              <p>{price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원</p>
-            </div>
-          )}
+        <div className='flex flex-col gap-1'>
+          <p className='text-xs text-subfont'>{getDateFunction(createdAt)}</p>
+          <div className='flex justify-between'>
+            {!price ? (
+              <div className='flex flex-col'>
+                <p>{message}</p>
+                <p>{reservationInfo}</p>
+              </div>
+            ) : (
+              <div className='flex flex-col'>
+                <p>{`${reservationInfo} ${message}`}</p>
+                <p>
+                  {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
+                </p>
+              </div>
+            )}
 
-          <img
-            src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg'
-            alt='스터디룸 사진'
-            className='h-10 w-10 object-cover'
-          />
+            <img
+              src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg'
+              alt='스터디룸 사진'
+              className='h-10 w-10 object-cover'
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 
-export default UpcomingNotiCard;
+export default UserNotiCard;

--- a/src/pages/UserNotiPage/components/UserNotiCard.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiCard.tsx
@@ -1,7 +1,13 @@
 import { getDateFunction } from '@utils/formatTime';
+import ShowWithinSevenDays from '@components/ShowWithinSevenDays';
 import type { UserNotification } from './UserNotiList';
 
-const UserNotiCard = ({ item }: { item: UserNotification }) => {
+interface UserNotiProps {
+  item: UserNotification;
+  showLabel: boolean;
+}
+
+const UserNotiCard = ({ item, showLabel }: UserNotiProps) => {
   const { type, message, reservationInfo, createdAt, price } = item;
 
   return (
@@ -38,6 +44,7 @@ const UserNotiCard = ({ item }: { item: UserNotification }) => {
           </div>
         </div>
       </div>
+      {showLabel ? <ShowWithinSevenDays label='7일 이내' /> : null}
     </>
   );
 };

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -1,4 +1,4 @@
-import UpcomingNotiCard from './UserNotiCard';
+import UserNotiCard from './UserNotiCard';
 
 export interface UserNotification {
   id: number;
@@ -20,10 +20,18 @@ const allNotification: UserNotification[] = [
   {
     id: 2,
     type: 'completeReservation',
-    message: '',
+    message: '예약이 완료되었습니다.',
     reservationInfo: '스터디랩 / ROOM A',
     price: 8000,
-    createdAt: '2024-11-12T14:00:00',
+    createdAt: '2024-11-16T14:00:00',
+  },
+  {
+    id: 2,
+    type: 'completeReservation',
+    message: '예약이 완료되었습니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    price: 8000,
+    createdAt: '2024-11-20T14:00:00',
   },
 ];
 
@@ -38,7 +46,7 @@ const UserNotiList = () => {
         <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px]'>
           {sortedNotification.map((item) => {
             return (
-              <UpcomingNotiCard
+              <UserNotiCard
                 key={item.id}
                 item={item}
               />

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -1,0 +1,57 @@
+import UpcomingNotiCard from './UserNotiCard';
+
+export interface UserNotification {
+  id: number;
+  type: string;
+  message: string;
+  reservationInfo: string;
+  price?: number;
+  createdAt: string;
+}
+
+const allNotification: UserNotification[] = [
+  {
+    id: 1,
+    type: 'upcoming',
+    message: '방문 24시간 전입니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    createdAt: '2024-11-14T00:00:00',
+  },
+  {
+    id: 2,
+    type: 'completeReservation',
+    message: '',
+    reservationInfo: '스터디랩 / ROOM A',
+    price: 8000,
+    createdAt: '2024-11-12T14:00:00',
+  },
+];
+
+const UserNotiList = () => {
+  const sortedNotification = [...allNotification].sort((b, a) => {
+    return +new Date(a.createdAt) - +new Date(b.createdAt);
+  });
+
+  return (
+    <>
+      {allNotification.length > 0 ? (
+        <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px]'>
+          {sortedNotification.map((item) => {
+            return (
+              <UpcomingNotiCard
+                key={item.id}
+                item={item}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className='mt-[47px] w-[375px] text-center text-[14px] font-normal text-subfont'>
+          알림이 없습니다.
+        </div>
+      )}
+    </>
+  );
+};
+
+export default UserNotiList;

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+import { getWithinSevenDays } from '@utils/formatTime';
 import UserNotiCard from './UserNotiCard';
 
 export interface UserNotification {
@@ -15,40 +17,72 @@ const allNotification: UserNotification[] = [
     type: 'upcoming',
     message: '방문 24시간 전입니다.',
     reservationInfo: '스터디랩 / ROOM A',
-    createdAt: '2024-11-14T00:00:00',
+    createdAt: '2024-11-02T00:00:00',
   },
   {
     id: 2,
+    type: 'upcoming',
+    message: '방문 24시간 전입니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    createdAt: '2024-11-01T00:00:00',
+  },
+  {
+    id: 3,
     type: 'completeReservation',
     message: '예약이 완료되었습니다.',
     reservationInfo: '스터디랩 / ROOM A',
     price: 8000,
-    createdAt: '2024-11-16T14:00:00',
+    createdAt: '2024-10-11T14:00:00',
   },
   {
-    id: 2,
+    id: 4,
     type: 'completeReservation',
     message: '예약이 완료되었습니다.',
     reservationInfo: '스터디랩 / ROOM A',
     price: 8000,
-    createdAt: '2024-11-20T14:00:00',
+    createdAt: '2024-11-20T16:00:00',
+  },
+  {
+    id: 5,
+    type: 'completeReservation',
+    message: '예약이 완료되었습니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    price: 8000,
+    createdAt: '2024-11-10T13:00:00',
   },
 ];
 
 const UserNotiList = () => {
-  const sortedNotification = [...allNotification].sort((b, a) => {
+  const [isLabel, setIsLabel] = useState<string | null>(null);
+  const sortedNotification = allNotification.sort((b, a) => {
     return +new Date(a.createdAt) - +new Date(b.createdAt);
   });
 
+  useEffect(() => {
+    if (sortedNotification) {
+      const reverseSortedList = [...sortedNotification].reverse();
+      const putLabel = reverseSortedList.find(
+        (item) => getWithinSevenDays(item.createdAt) === '7일 이내',
+      );
+
+      if (putLabel) {
+        setIsLabel(putLabel.createdAt);
+      } else {
+        setIsLabel(null);
+      }
+    }
+  }, [sortedNotification]);
+
   return (
     <>
-      {allNotification.length > 0 ? (
+      {sortedNotification && sortedNotification.length > 0 ? (
         <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px]'>
           {sortedNotification.map((item) => {
             return (
               <UserNotiCard
                 key={item.id}
                 item={item}
+                showLabel={item.createdAt === isLabel}
               />
             );
           })}

--- a/src/pages/UserNotiPage/index.tsx
+++ b/src/pages/UserNotiPage/index.tsx
@@ -1,11 +1,13 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
+import UserNotiList from './components/UserNotiList';
 
 const UserNotiPage = () => {
   return (
     <MainLayout>
       <HeaderOnlyTitle title='알림' />
       <hr className='fixed top-[93px] mx-[22.5px] h-0.5 w-custom border-0 bg-black' />
+      <UserNotiList />
     </MainLayout>
   );
 };

--- a/src/pages/UserNotiPage/index.tsx
+++ b/src/pages/UserNotiPage/index.tsx
@@ -1,0 +1,13 @@
+import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
+import MainLayout from '@layouts/MainLayout';
+
+const UserNotiPage = () => {
+  return (
+    <MainLayout>
+      <HeaderOnlyTitle title='알림' />
+      <hr className='fixed top-[93px] mx-[22.5px] h-0.5 w-custom border-0 bg-black' />
+    </MainLayout>
+  );
+};
+
+export default UserNotiPage;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -14,6 +14,7 @@ import ReviewListPage from '@pages/ReviewListPage';
 import ManagementPlacePage from '@pages/ManagementPlacePage';
 import ManagementReserverPage from '@pages/ManagementReserverPage';
 import RegisterSpace from '@pages/RegisterSpace';
+import UserNotiPage from '@pages/UserNotiPage';
 
 const router = createBrowserRouter([
   {
@@ -59,6 +60,10 @@ const router = createBrowserRouter([
   {
     path: '/review-list',
     element: <ReviewListPage />,
+  },
+  {
+    path: '/user-noti',
+    element: <UserNotiPage />,
   },
   {
     path: '/host-page',

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -18,3 +18,40 @@ export const getTimeFunction = (timeString: string) => {
 
   return formattedTimeString;
 };
+
+// 시간 차이 구하는 함수
+export const getTimeDifference = (timeString: string) => {
+  const milliSeconds = +new Date() - +new Date(timeString);
+  let message = '';
+
+  const seconds = milliSeconds / 1000;
+  if (seconds < 60) {
+    message = `방금 전`;
+  }
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    message = `${Math.floor(minutes)}분 전`;
+  }
+  const hours = minutes / 60;
+  if (hours < 24) {
+    message = `${Math.floor(hours)}시간 전`;
+  }
+  const days = hours / 24;
+  if (days < 7) {
+    message = `${Math.floor(days)}일 전`;
+  }
+
+  return message;
+};
+
+export const getWithinSevenDays = (timeString: string) => {
+  const milliSeconds = +new Date() - +new Date(timeString);
+  const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+  let message = '';
+
+  if (milliSeconds < SEVEN_DAYS) {
+    message = '7일 이내';
+  }
+
+  return message;
+};


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사용자 알림 페이지 마크업 구현

## 📝 요구 사항과 구현 내용
- 사용자 알림 페이지 라우터 연결
- 사용자 알림 페이지 마크업 구현
- formatTime.ts 파일에 시간차 구하는 함수, 7일 이내인지 판단하는 함수 추가
- 공통 컴포넌트에 7일 이내 라벨 추가(사업자 알림에서도 사용될 예정)

## 💬 PR 포인트 & 궁금한 점
- 7일 이내 라벨 붙이는 부분에서 임의로 만들어둔 객체 id가 중복되어서 같은 알림이 두 번 보이거나 이전 값이 사라지지 않는 현상이 있었습니다...! 일단 id값을 고유하게 줘서 해당 현상은 해결된 것 같은데 나중에 api 연결하면서 마크업 구조 수정할 때 한 번 더 확인해보겠습니다!