### PR TITLE
💄 Design : 사업자 알림 페이지 마크업 구현

### DIFF
--- a/src/pages/HostNotiPage/components/HostNotiCard.tsx
+++ b/src/pages/HostNotiPage/components/HostNotiCard.tsx
@@ -1,39 +1,41 @@
 import { getDateFunction } from '@utils/formatTime';
 import ShowWithinSevenDays from '@components/ShowWithinSevenDays';
-import type { UserNotification } from './UserNotiList';
+import { UserNotification } from '@pages/UserNotiPage/components/UserNotiList';
 
-interface UserNotiProps {
+interface HostNotiProps {
   item: UserNotification;
   showLabel: boolean;
 }
 
-const UserNotiCard = ({ item, showLabel }: UserNotiProps) => {
-  const { type, message, reservationInfo, createdAt, price } = item;
+const HostNotiCard = ({ item, showLabel }: HostNotiProps) => {
+  const { type, message, reservationInfo, createdAt } = item;
 
   return (
     <>
       <div className='mx-auto flex w-[100%] flex-col gap-3 text-sm active:bg-[#e9e9e9]'>
         <div className='mx-auto w-custom px-1.5 py-[13px]'>
-          {type === 'upcoming' ? (
-            <p className='font-medium'>다가오는 일정</p>
+          {type === 'newReview' ? (
+            <p className='font-medium'>새 리뷰 등록</p>
           ) : (
-            <p className='font-medium'>예약 완료</p>
+            <p className='font-medium'>새로운 예약</p>
           )}
 
           <div className='flex flex-col gap-1'>
             <p className='text-xs text-subfont'>{getDateFunction(createdAt)}</p>
-            <div className='flex justify-between'>
-              {!price ? (
+            <div className='flex justify-between gap-3'>
+              {type === 'newReview' ? (
                 <div className='flex w-[260px] flex-col'>
-                  <p className='w-[100%]'>{message}</p>
-                  <p className='w-[100%]'>{reservationInfo}</p>
+                  <p className='w-[100%]'>
+                    {reservationInfo}에 새로운 리뷰가 등록되었습니다.
+                  </p>
+                  <p className='w-[100%] overflow-hidden text-ellipsis whitespace-nowrap text-[#666666]'>
+                    {message}
+                  </p>
                 </div>
               ) : (
                 <div className='flex w-[260px] flex-col'>
-                  <p className='w-[100%]'>{`${reservationInfo} ${message}`}</p>
-                  <p className='w-[100%]'>
-                    {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
-                  </p>
+                  <p className='w-[100%]'>{message}</p>
+                  <p className='w-[100%]'>{reservationInfo}</p>
                 </div>
               )}
 
@@ -51,4 +53,4 @@ const UserNotiCard = ({ item, showLabel }: UserNotiProps) => {
   );
 };
 
-export default UserNotiCard;
+export default HostNotiCard;

--- a/src/pages/HostNotiPage/components/HostNotiList.tsx
+++ b/src/pages/HostNotiPage/components/HostNotiList.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { getWithinSevenDays } from '@utils/formatTime';
+import { UserNotification } from '@pages/UserNotiPage/components/UserNotiList';
+import HostNotiCard from './HostNotiCard';
+
+const allNotification: UserNotification[] = [
+  {
+    id: 1,
+    type: 'newReservation',
+    message: '홍길동님의 예약이 등록되었습니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    createdAt: '2024-11-02T00:00:00',
+  },
+  {
+    id: 2,
+    type: 'newReview',
+    message:
+      '스터디룸이 매우 깨끗하고 조용해서 집중도가 높아졌습니다. 시설도 최신이고 필요한 장비도 모두 갖춰져 있어 학습에 최적화된 환경이었어요. 예약과 이용 절차도 간편해 만족도가 높습니다.',
+    reservationInfo: '스터디랩',
+    createdAt: '2024-11-23T00:00:00',
+  },
+  {
+    id: 3,
+    type: 'newReview',
+    message:
+      '스터디룸이 매우 깨끗하고 조용해서 집중도가 높아졌습니다. 시설도 최신이고 필요한 장비도 모두 갖춰져 있어 학습에 최적화된 환경이었어요. 예약과 이용 절차도 간편해 만족도가 높습니다.',
+    reservationInfo: '스터디랩',
+    createdAt: '2024-11-19T14:00:00',
+  },
+  {
+    id: 4,
+    type: 'newReservation',
+    message: 'HYUN님의 예약이 등록되었습니다.',
+    reservationInfo: '스터디랩 / ROOM A',
+    createdAt: '2024-11-22T16:00:00',
+  },
+];
+
+const HostNotiList = () => {
+  const [isLabel, setIsLabel] = useState<string | null>(null);
+  const sortedNotification = allNotification.sort((b, a) => {
+    return +new Date(a.createdAt) - +new Date(b.createdAt);
+  });
+
+  useEffect(() => {
+    if (sortedNotification) {
+      const reverseSortedList = [...sortedNotification].reverse();
+      const putLabel = reverseSortedList.find(
+        (item) => getWithinSevenDays(item.createdAt) === '7일 이내',
+      );
+
+      if (putLabel) {
+        setIsLabel(putLabel.createdAt);
+      } else {
+        setIsLabel(null);
+      }
+    }
+  }, [sortedNotification]);
+
+  return (
+    <>
+      {sortedNotification && sortedNotification.length > 0 ? (
+        <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px]'>
+          {sortedNotification.map((item) => {
+            return (
+              <HostNotiCard
+                key={item.id}
+                item={item}
+                showLabel={item.createdAt === isLabel}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className='mt-[47px] w-[375px] text-center text-[14px] font-normal text-subfont'>
+          알림이 없습니다.
+        </div>
+      )}
+    </>
+  );
+};
+
+export default HostNotiList;

--- a/src/pages/HostNotiPage/index.tsx
+++ b/src/pages/HostNotiPage/index.tsx
@@ -1,0 +1,13 @@
+import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
+import MainLayout from '@layouts/MainLayout';
+
+const HostNotiPage = () => {
+  return (
+    <MainLayout>
+      <HeaderOnlyTitle title='알림' />
+      <hr className='fixed top-[93px] mx-[22.5px] h-0.5 w-custom border-0 bg-black' />
+    </MainLayout>
+  );
+};
+
+export default HostNotiPage;

--- a/src/pages/HostNotiPage/index.tsx
+++ b/src/pages/HostNotiPage/index.tsx
@@ -1,11 +1,13 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
+import HostNotiList from './components/HostNotiList';
 
 const HostNotiPage = () => {
   return (
     <MainLayout>
       <HeaderOnlyTitle title='알림' />
       <hr className='fixed top-[93px] mx-[22.5px] h-0.5 w-custom border-0 bg-black' />
+      <HostNotiList />
     </MainLayout>
   );
 };

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -2,7 +2,7 @@ import { MdArrowForwardIos } from 'react-icons/md';
 import { getDateFunction } from '@utils/formatTime';
 import ButtonInCard from '@components/ButtonInCard';
 import ListStyle from '@components/ListStyle';
-import { WorkPlace } from './ManagementPlaceList';
+import type { WorkPlace } from './ManagementPlaceList';
 
 const ManagementPlaceCard = ({ item }: { item: WorkPlace }) => {
   const {
@@ -50,7 +50,7 @@ const ManagementPlaceCard = ({ item }: { item: WorkPlace }) => {
       </div>
 
       <div className='self-end'>
-        <ButtonInCard name='상세 보기' />
+        <ButtonInCard name='수정' />
       </div>
     </div>
   );

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -17,6 +17,7 @@ import RegisterSpace from '@pages/RegisterSpace';
 import UserNotiPage from '@pages/UserNotiPage';
 import AddRoom from '@pages/AddRoom';
 import SearchResult from '@pages/SearchResult';
+import HostNotiPage from '@pages/HostNotiPage';
 
 const router = createBrowserRouter([
   {
@@ -82,6 +83,10 @@ const router = createBrowserRouter([
   {
     path: '/management-reserver-list',
     element: <ManagementReserverPage />,
+  },
+  {
+    path: '/host-noti',
+    element: <HostNotiPage />,
   },
   {
     path: '/search',


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업자 알림 페이지 마크업 구현

## 📝 요구 사항과 구현 내용
- 사업자 알림 페이지 라우터 연결
- 사업자 알림 페이지 마크업 구현
- 사용자 알림, 사업자 알림 페이지 알림 클릭하면 배경색 바뀌도록 active 추가

## 💬 PR 포인트 & 궁금한 점
- 알림 아이콘이랑 페이지 연결하는건 나중에 api 연동하고 나서 하겠습니다!
- 사업장 관리 페이지 상세 보기 버튼을 다시 수정 버튼으로 변경하였습니다