### PR TITLE
💄 Design : 모달 컴포넌트 마크업 구현

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -6,8 +6,8 @@ interface ModalProps {
 
 const Modal = ({ message, cancelButton, confirmButton }: ModalProps) => {
   return (
-    <div className='fixed left-0 top-0 z-[1100] flex h-[100%] w-[100%] items-center justify-center bg-[rgba(0,0,0,0.4)]'>
-      <div className='flex h-auto min-h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)]'>
+    <div className='fixed left-[50%] top-0 z-[1500] flex h-[100%] w-[375px] translate-x-[-50%] items-center justify-center bg-[rgba(0,0,0,0.4)]'>
+      <div className='flex h-auto min-h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)] text-center'>
         <div className='flex h-auto min-h-[calc(100%-44px)] flex-grow items-center justify-center px-5 py-4'>
           {message}
         </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,35 @@
+interface ModalProps {
+  message: string;
+  cancelButton: React.MouseEventHandler<HTMLButtonElement>;
+  confirmButton: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const Modal = ({ message, cancelButton, confirmButton }: ModalProps) => {
+  return (
+    <div className='fixed left-0 top-0 z-[1100] flex h-[100%] w-[100%] items-center justify-center bg-[rgba(0,0,0,0.4)]'>
+      <div className='flex h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)]'>
+        <div className='flex h-[calc(100%-44px)] items-center justify-center'>
+          {message}
+        </div>
+        <div className='flex h-[44px] border-t-[0.5px] border-subfont'>
+          <button
+            type='button'
+            className='w-[50%] border-r-[0.5px] border-subfont'
+            onClick={cancelButton}
+          >
+            취소
+          </button>
+          <button
+            type='button'
+            onClick={confirmButton}
+            className='w-[50%] active:text-primary'
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,11 +7,11 @@ interface ModalProps {
 const Modal = ({ message, cancelButton, confirmButton }: ModalProps) => {
   return (
     <div className='fixed left-0 top-0 z-[1100] flex h-[100%] w-[100%] items-center justify-center bg-[rgba(0,0,0,0.4)]'>
-      <div className='flex h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)]'>
-        <div className='flex h-[calc(100%-44px)] items-center justify-center'>
+      <div className='flex h-auto min-h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)]'>
+        <div className='flex h-auto min-h-[calc(100%-44px)] flex-grow items-center justify-center px-5 py-4'>
           {message}
         </div>
-        <div className='flex h-[44px] border-t-[0.5px] border-subfont'>
+        <div className='flex h-[44px] w-[100%] border-t-[0.5px] border-subfont'>
           <button
             type='button'
             className='w-[50%] border-r-[0.5px] border-subfont'

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -104,14 +104,14 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
             {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
           </span>
         </div>
+        {modalOpen && (
+          <Modal
+            message='결제를 취소하시겠습니까?'
+            cancelButton={() => setModalOpen(false)}
+            confirmButton={cancelPayment}
+          />
+        )}
       </div>
-      {modalOpen && (
-        <Modal
-          message='결제를 취소하시겠습니까?'
-          cancelButton={() => setModalOpen(false)}
-          confirmButton={cancelPayment}
-        />
-      )}
     </>
   );
 };

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -3,11 +3,15 @@ import ButtonInCard from '@components/ButtonInCard';
 import { Reservation } from '@pages/WriteReviewPage/components/ReservationInfo';
 import { useNavigate } from 'react-router-dom';
 import ListStyle from '@components/ListStyle';
+import { useState } from 'react';
+import Modal from '@components/Modal';
 
 const ReservationDetailCard = ({ item }: { item: Reservation }) => {
   const { name, date, time, endtime, room, people, price, img, createdAt } =
     item;
   const navigate = useNavigate();
+
+  const [modalOpen, setModalOpen] = useState(false);
 
   const now = new Date();
   const gap = +new Date(time) - +now;
@@ -37,61 +41,78 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
     navigate('/write-review');
   };
 
-  return (
-    <div className='mx-auto flex w-custom flex-col gap-[18px] border-b border-solid border-b-black px-[13px] py-[24px]'>
-      <div className='flex items-center gap-[18px]'>
-        <img
-          src={img}
-          alt='스터디룸 사진'
-          className='h-[118px] w-[118px] object-cover'
-        />
+  const cancelPayment = () => {
+    console.log('결제 취소');
+    setModalOpen(() => false);
+  };
 
-        <div className='flex w-[auto] flex-col gap-[7px]'>
-          <p className='text-[16px] font-medium'>{name}</p>
-          <ul className='flex flex-col gap-[2px] text-[12px]'>
-            <ListStyle
-              name='예약일'
-              value={date}
+  return (
+    <>
+      <div className='mx-auto flex w-custom flex-col gap-[18px] border-b border-solid border-b-black px-[13px] py-[24px]'>
+        <div className='flex items-center gap-[18px]'>
+          <img
+            src={img}
+            alt='스터디룸 사진'
+            className='h-[118px] w-[118px] object-cover'
+          />
+
+          <div className='flex w-[auto] flex-col gap-[7px]'>
+            <p className='text-[16px] font-medium'>{name}</p>
+            <ul className='flex flex-col gap-[2px] text-[12px]'>
+              <ListStyle
+                name='예약일'
+                value={date}
+              />
+              <ListStyle
+                name='예약시간'
+                value={`${getTimeFunction(time)} ~ ${getTimeFunction(endtime as string)}`}
+              />
+              <ListStyle
+                name='예약된 룸'
+                value={room}
+              />
+              <ListStyle
+                name='인원'
+                value={`${people}인`}
+              />
+              <ListStyle
+                name='결제일'
+                value={getDateFunction(createdAt as string)}
+              />
+            </ul>
+          </div>
+        </div>
+        <div className='flex items-center justify-between'>
+          {buttonType(gap) === 'cancelPayment' && (
+            <ButtonInCard
+              name='결제 취소'
+              onClickFunction={() => setModalOpen(true)}
             />
-            <ListStyle
-              name='예약시간'
-              value={`${getTimeFunction(time)} ~ ${getTimeFunction(endtime as string)}`}
+          )}
+          {buttonType(gap) === 'review' && (
+            <ButtonInCard
+              name='리뷰 작성'
+              onClickFunction={handleReviewButton}
             />
-            <ListStyle
-              name='예약된 룸'
-              value={room}
-            />
-            <ListStyle
-              name='인원'
-              value={`${people}인`}
-            />
-            <ListStyle
-              name='결제일'
-              value={getDateFunction(createdAt as string)}
-            />
-          </ul>
+          )}
+          {buttonType(gap) === 'none' && (
+            <span className='text-[12px] text-primary'>
+              방문 24시간 전입니다.
+            </span>
+          )}
+          <span className='self-end text-[14px] font-normal'>
+            {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
+          </span>
         </div>
       </div>
-      <div className='flex items-center justify-between'>
-        {buttonType(gap) === 'cancelPayment' && (
-          <ButtonInCard name='결제 취소' />
-        )}
-        {buttonType(gap) === 'review' && (
-          <ButtonInCard
-            name='리뷰 작성'
-            onClickFunction={handleReviewButton}
-          />
-        )}
-        {buttonType(gap) === 'none' && (
-          <span className='text-[12px] text-primary'>
-            방문 24시간 전입니다.
-          </span>
-        )}
-        <span className='self-end text-[14px] font-normal'>
-          {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
-        </span>
-      </div>
-    </div>
+      {modalOpen && (
+        <Modal
+          message='결제를 취소하시겠습니까?'
+          cancelButton={() => setModalOpen(false)}
+          confirmButton={cancelPayment}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/ReservationListPage/components/ReservationList.tsx
+++ b/src/pages/ReservationListPage/components/ReservationList.tsx
@@ -62,7 +62,7 @@ const ReservationList = () => {
   return (
     <>
       {reservationCardList.length > 0 ? (
-        <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
+        <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
           {sortedReservationList.map((item) => {
             return (
               <ReservationDetailCard


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 모달 컴포넌트 마크업 구현

## 📝 요구 사항과 구현 내용
- 모달창 마크업 구현(components/Modal.tsx)
- 예약 내역 페이지 결제 취소 버튼과 모달창 연결
- 예약 내역 페이지 바닥 padding값 부여(`pb-24`: 96px) 
   너무 바닥이랑 붙어 있어서 추가했습니다! 다른 페이지에도 같은 값 적용할 예정입니다. 네비게이션 있는 쪽은 이것보다 더 주면 좋을 것 같습니다!

## 💬 PR 포인트
- 모달창 사용법
  - 모달을 사용하려는 컴포넌트에서 `const [modalOpen, setModalOpen] = useState(false);` 작성
  - 아래와 같이 message, cancelButton, confirmButton에 필요한 항목 작성
    ```
    {modalOpen && (
      <Modal
        message='결제를 취소하시겠습니까?'
        cancelButton={() => setModalOpen(false)}
        confirmButton={cancelPayment}
      />
    )}
    ```
    `messge`: 모달창에 들어갈 문구
    `onCancelButtonClick`: 모달창 취소 버튼 눌렀을 때 실행될 함수 작성(위 예시에서는 모달창 닫는 함수)
    `onConfirmButtonClick`: 확인 버튼 눌렀을 때 실행될 함수 작성

  - 확인 버튼 누른 후 모달창 닫히게 하려면 confirmButton에 연결하는 함수를 아래와 같이 작성(참고) 
    ```
    const cancelPayment = () => {
      console.log('결제 취소');
      setModalOpen(() => false);
    };
    ```
    pages/ReservationListPage/ReservationDetailCard.tsx 참고하시고 이상한 점이나 고쳐야 할 부분 있으면 말씀해주세요:)