### PR TITLE
💄Design : 결제페이지 마크업 구현

### DIFF
--- a/src/components/CheckAgree.tsx
+++ b/src/components/CheckAgree.tsx
@@ -1,0 +1,35 @@
+interface CheckAgreeProps {
+  checkId: string;
+  isCheck: boolean;
+  description: string;
+  onChangeChecked: (checked: boolean, id: string) => void;
+  children?: React.ReactNode;
+}
+
+const CheckAgree = (props: CheckAgreeProps) => {
+  const { checkId, isCheck, description, onChangeChecked, children } = props;
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChangeChecked(e.target.checked, checkId);
+  };
+
+  return (
+    <div className='flex gap-1'>
+      <input
+        type='checkbox'
+        id={checkId}
+        name={checkId}
+        checked={isCheck}
+        onChange={handleChange}
+        className='h-4 w-4'
+      />
+      <div className='flex w-full items-center justify-between'>
+        <label htmlFor={checkId}>
+          <span className='font-normal'>[필수]</span> {description}
+        </label>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default CheckAgree;

--- a/src/components/DetailTitle.tsx
+++ b/src/components/DetailTitle.tsx
@@ -1,0 +1,18 @@
+interface DetailTitleProps {
+  title: string;
+  children?: React.ReactNode;
+}
+
+const DetailTitle = ({ title, children }: DetailTitleProps) => {
+  return (
+    <div>
+      <div className='flex items-center justify-between'>
+        <p>{title}</p>
+        {children}
+      </div>
+      <hr className='mt-2 w-custom border border-black' />
+    </div>
+  );
+};
+
+export default DetailTitle;

--- a/src/pages/PaymentPage/components/CancelRule.tsx
+++ b/src/pages/PaymentPage/components/CancelRule.tsx
@@ -1,59 +1,17 @@
+import DetailTitle from '@components/DetailTitle';
+
 const CancelRule = () => {
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <div>
-        <p>예약 안내</p>
-        <hr className='mt-2 border border-black' />
-      </div>
+      <DetailTitle title='취소 / 환불 규정' />
       <div className='flex flex-col gap-2 text-xs'>
-        <div className='flex items-center gap-1'>
-          <input
-            type='checkbox'
-            id='reservation'
-            className='h-4 w-4'
-          />
-          <div className='flex w-full items-center justify-between'>
-            <label htmlFor='reservation'>
-              <span className='font-normal'>[필수]</span> 개인정보 수집/이용
-              동의
-            </label>
-            <button
-              type='button'
-              className='text-subfont underline'
-            >
-              보기
-            </button>
-          </div>
+        <div className='flex items-center justify-between'>
+          <span>이용 24시간 전까지</span>
+          <span className='font-normal'>총 금액의 100% 환불</span>
         </div>
-        <div className='flex items-center gap-1'>
-          <input
-            type='checkbox'
-            id='reservation'
-            className='h-4 w-4'
-          />
-          <div className='flex w-full items-center justify-between'>
-            <label htmlFor='reservation'>
-              <span className='font-normal'>[필수]</span> 개인정보 제3자 제공
-              동의
-            </label>
-            <button
-              type='button'
-              className='text-subfont underline'
-            >
-              보기
-            </button>
-          </div>
-        </div>
-        <div className='flex items-center gap-1'>
-          <input
-            type='checkbox'
-            id='reservation'
-            className='h-4 w-4'
-          />
-          <label htmlFor='reservation'>
-            <span className='font-normal'>[필수]</span> 환불규정 안내에 대한
-            동의
-          </label>
+        <div className='flex items-center justify-between'>
+          <span>이용 24시간 이내</span>
+          <span className='font-normal'>환불 불가</span>
         </div>
       </div>
     </div>

--- a/src/pages/PaymentPage/components/CancelRule.tsx
+++ b/src/pages/PaymentPage/components/CancelRule.tsx
@@ -1,0 +1,63 @@
+const CancelRule = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <div>
+        <p>예약 안내</p>
+        <hr className='mt-2 border border-black' />
+      </div>
+      <div className='flex flex-col gap-2 text-xs'>
+        <div className='flex items-center gap-1'>
+          <input
+            type='checkbox'
+            id='reservation'
+            className='h-4 w-4'
+          />
+          <div className='flex w-full items-center justify-between'>
+            <label htmlFor='reservation'>
+              <span className='font-normal'>[필수]</span> 개인정보 수집/이용
+              동의
+            </label>
+            <button
+              type='button'
+              className='text-subfont underline'
+            >
+              보기
+            </button>
+          </div>
+        </div>
+        <div className='flex items-center gap-1'>
+          <input
+            type='checkbox'
+            id='reservation'
+            className='h-4 w-4'
+          />
+          <div className='flex w-full items-center justify-between'>
+            <label htmlFor='reservation'>
+              <span className='font-normal'>[필수]</span> 개인정보 제3자 제공
+              동의
+            </label>
+            <button
+              type='button'
+              className='text-subfont underline'
+            >
+              보기
+            </button>
+          </div>
+        </div>
+        <div className='flex items-center gap-1'>
+          <input
+            type='checkbox'
+            id='reservation'
+            className='h-4 w-4'
+          />
+          <label htmlFor='reservation'>
+            <span className='font-normal'>[필수]</span> 환불규정 안내에 대한
+            동의
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CancelRule;

--- a/src/pages/PaymentPage/components/PaymentAgree.tsx
+++ b/src/pages/PaymentPage/components/PaymentAgree.tsx
@@ -1,0 +1,44 @@
+const PaymentAgree = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <div>
+        <p>주문 내용 확인 및 결제 동의</p>
+        <hr className='mt-2 border border-black' />
+      </div>
+      <div className='flex flex-col gap-2 text-xs'>
+        <div className='flex items-center gap-1'>
+          <input
+            type='checkbox'
+            id='reservation'
+            className='h-4 w-4'
+          />
+          <div className='flex w-full items-center justify-between'>
+            <label htmlFor='reservation'>
+              <span className='font-normal'>[필수]</span> 결제 서비스 이용 약관
+            </label>
+            <button
+              type='button'
+              className='text-subfont underline'
+            >
+              보기
+            </button>
+          </div>
+        </div>
+        <div className='flex gap-1'>
+          <input
+            type='checkbox'
+            id='reservation'
+            className='h-4 w-4'
+          />
+
+          <label htmlFor='reservation'>
+            <span className='font-normal'>[필수]</span> 주문정보 및 결제정보를
+            확인하였으며, 구매진행에 동의합니다.
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentAgree;

--- a/src/pages/PaymentPage/components/PaymentAgree.tsx
+++ b/src/pages/PaymentPage/components/PaymentAgree.tsx
@@ -1,41 +1,42 @@
+import CheckAgree from '@components/CheckAgree';
+import DetailTitle from '@components/DetailTitle';
+import { useState } from 'react';
+
 const PaymentAgree = () => {
+  const [checkedList, setCheckedList] = useState<string[]>([]);
+  const handleCheckItem = (checked: boolean, id: string) => {
+    if (checked) {
+      setCheckedList((prev) => [...prev, id]);
+    } else {
+      setCheckedList(checkedList.filter((item) => item !== id));
+    }
+  };
+
+  const isChecked = (id: string) => checkedList.includes(id);
+
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <div>
-        <p>주문 내용 확인 및 결제 동의</p>
-        <hr className='mt-2 border border-black' />
-      </div>
+      <DetailTitle title='주문 내용 확인 및 결제 동의' />
       <div className='flex flex-col gap-2 text-xs'>
-        <div className='flex items-center gap-1'>
-          <input
-            type='checkbox'
-            id='reservation'
-            className='h-4 w-4'
-          />
-          <div className='flex w-full items-center justify-between'>
-            <label htmlFor='reservation'>
-              <span className='font-normal'>[필수]</span> 결제 서비스 이용 약관
-            </label>
-            <button
-              type='button'
-              className='text-subfont underline'
-            >
-              보기
-            </button>
-          </div>
-        </div>
-        <div className='flex gap-1'>
-          <input
-            type='checkbox'
-            id='reservation'
-            className='h-4 w-4'
-          />
-
-          <label htmlFor='reservation'>
-            <span className='font-normal'>[필수]</span> 주문정보 및 결제정보를
-            확인하였으며, 구매진행에 동의합니다.
-          </label>
-        </div>
+        <CheckAgree
+          checkId='payment1'
+          isCheck={isChecked('payment1')}
+          description='결제 서비스 이용 약관'
+          onChangeChecked={handleCheckItem}
+        >
+          <button
+            type='button'
+            className='text-subfont underline'
+          >
+            보기
+          </button>
+        </CheckAgree>
+        <CheckAgree
+          checkId='payment2'
+          isCheck={isChecked('payment2')}
+          description='주문정보 및 결제정보를 확인하였으며, 구매진행에 동의합니다.'
+          onChangeChecked={handleCheckItem}
+        />
       </div>
     </div>
   );

--- a/src/pages/PaymentPage/components/PaymentRoomCard.tsx
+++ b/src/pages/PaymentPage/components/PaymentRoomCard.tsx
@@ -1,0 +1,47 @@
+import { GrNext } from 'react-icons/gr';
+
+const PaymentRoomCard = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col'>
+      <div className='flex items-center justify-between'>
+        <p>스터디룸 정보</p>
+        <button
+          type='button'
+          className='flex items-center justify-center gap-1 text-xs text-subfont'
+        >
+          123 스터디룸 <GrNext />
+        </button>
+      </div>
+      <hr className='my-2 border border-black' />
+      <div className='flex h-[120px] w-custom items-center justify-center gap-[18px] rounded-[10px] shadow-custom'>
+        <img
+          src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg?type=w1100'
+          className='h-[94px] w-[94px] object-cover'
+          alt='결제 스터디룸 사진'
+        />
+        <div className='flex w-[186px] flex-col gap-2'>
+          <div className='font-normal'>ROOM A</div>
+          <div className='flex flex-col gap-1 text-xs'>
+            <div className='flex gap-[10px]'>
+              <span>장소</span>
+              <span className='font-normal'>ABC 스터디룸</span>
+            </div>
+            <div className='flex gap-[10px]'>
+              <span>일정</span>
+              <div className='flex gap-[6px]'>
+                <span className='font-normal'>11월 16일(토)</span>
+                <span className='font-normal'>16:00 - 18:00</span>
+              </div>
+            </div>
+            <div className='flex gap-[10px]'>
+              <span>인원</span>
+              <span className='font-normal'>4명</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentRoomCard;

--- a/src/pages/PaymentPage/components/PaymentRoomCard.tsx
+++ b/src/pages/PaymentPage/components/PaymentRoomCard.tsx
@@ -1,18 +1,17 @@
+import DetailTitle from '@components/DetailTitle';
 import { GrNext } from 'react-icons/gr';
 
 const PaymentRoomCard = () => {
   return (
-    <div className='mx-auto mt-8 flex w-custom flex-col'>
-      <div className='flex items-center justify-between'>
-        <p>스터디룸 정보</p>
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <DetailTitle title='룸 상세 정보'>
         <button
           type='button'
           className='flex items-center justify-center gap-1 text-xs text-subfont'
         >
           123 스터디룸 <GrNext />
         </button>
-      </div>
-      <hr className='my-2 border border-black' />
+      </DetailTitle>
       <div className='flex h-[120px] w-custom items-center justify-center gap-[18px] rounded-[10px] shadow-custom'>
         <img
           src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg?type=w1100'

--- a/src/pages/PaymentPage/components/ReservationGuide.tsx
+++ b/src/pages/PaymentPage/components/ReservationGuide.tsx
@@ -1,19 +1,56 @@
+import CheckAgree from '@components/CheckAgree';
+import DetailTitle from '@components/DetailTitle';
+import { useState } from 'react';
+
 const ReservationGuide = () => {
+  const [checkedList, setCheckedList] = useState<string[]>([]);
+  const handleCheckItem = (checked: boolean, id: string) => {
+    if (checked) {
+      setCheckedList((prev) => [...prev, id]);
+    } else {
+      setCheckedList(checkedList.filter((item) => item !== id));
+    }
+  };
+
+  const isChecked = (id: string) => checkedList.includes(id);
+
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <div>
-        <p>취소 / 환불 규정</p>
-        <hr className='mt-2 border border-black' />
-      </div>
+      <DetailTitle title='예약 안내' />
       <div className='flex flex-col gap-2 text-xs'>
-        <div className='flex items-center justify-between'>
-          <span>이용 24시간 전까지</span>
-          <span className='font-normal'>총 금액의 100% 환불</span>
-        </div>
-        <div className='flex items-center justify-between'>
-          <span>이용 24시간 이내</span>
-          <span className='font-normal'>환불 불가</span>
-        </div>
+        <CheckAgree
+          checkId='reservation1'
+          isCheck={isChecked('reservation1')}
+          description='개인정보 수집/이용
+              동의'
+          onChangeChecked={handleCheckItem}
+        >
+          <button
+            type='button'
+            className='text-subfont underline'
+          >
+            보기
+          </button>
+        </CheckAgree>
+        <CheckAgree
+          checkId='reservation2'
+          isCheck={isChecked('reservation2')}
+          description='개인정보 제3자 제공 동의'
+          onChangeChecked={handleCheckItem}
+        >
+          <button
+            type='button'
+            className='text-subfont underline'
+          >
+            보기
+          </button>
+        </CheckAgree>
+        <CheckAgree
+          checkId='reservation3'
+          isCheck={isChecked('reservation3')}
+          description='환불규정 안내에 대한 동의'
+          onChangeChecked={handleCheckItem}
+        />
       </div>
     </div>
   );

--- a/src/pages/PaymentPage/components/ReservationGuide.tsx
+++ b/src/pages/PaymentPage/components/ReservationGuide.tsx
@@ -1,0 +1,22 @@
+const ReservationGuide = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <div>
+        <p>취소 / 환불 규정</p>
+        <hr className='mt-2 border border-black' />
+      </div>
+      <div className='flex flex-col gap-2 text-xs'>
+        <div className='flex items-center justify-between'>
+          <span>이용 24시간 전까지</span>
+          <span className='font-normal'>총 금액의 100% 환불</span>
+        </div>
+        <div className='flex items-center justify-between'>
+          <span>이용 24시간 이내</span>
+          <span className='font-normal'>환불 불가</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationGuide;

--- a/src/pages/PaymentPage/components/ReservationInfo.tsx
+++ b/src/pages/PaymentPage/components/ReservationInfo.tsx
@@ -1,6 +1,25 @@
 import DetailTitle from '@components/DetailTitle';
+import { useState } from 'react';
 
 const ReservationInfo = () => {
+  const [phoneNumber, setPhoneNumber] = useState<string>('');
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > 13) {
+      e.target.value = e.target.value.substring(0, 13);
+    }
+    const onlyNumber = e.target.value.replace(/[^0-9]/g, '');
+    let formattedValue = '';
+    if (onlyNumber.length <= 3) {
+      formattedValue = onlyNumber;
+    } else if (onlyNumber.length <= 7) {
+      formattedValue = `${onlyNumber.slice(0, 3)}-${onlyNumber.slice(3)}`;
+    } else {
+      formattedValue = `${onlyNumber.slice(0, 3)}-${onlyNumber.slice(3, 7)}-${onlyNumber.slice(7, 11)}`;
+    }
+    setPhoneNumber(formattedValue);
+  };
+
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
       <DetailTitle title='예약자 정보' />
@@ -18,6 +37,8 @@ const ReservationInfo = () => {
           <input
             type='text'
             placeholder='전화번호를 입력하세요.'
+            value={phoneNumber}
+            onChange={handlePhoneChange}
             className='h-[38px] w-[200px] rounded-[5px] border-[1px] border-subfont px-[10px] py-[10px] focus:border-focusColor focus:outline-none'
           />
         </div>

--- a/src/pages/PaymentPage/components/ReservationInfo.tsx
+++ b/src/pages/PaymentPage/components/ReservationInfo.tsx
@@ -1,0 +1,30 @@
+const ReservationInfo = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <div>
+        <p>예약자 정보</p>
+        <hr className='mt-2 border border-black' />
+      </div>
+      <div className='flex w-custom flex-col gap-[10px]'>
+        <div className='flex w-full items-center justify-between text-sm'>
+          <p>예약자명</p>
+          <input
+            type='text'
+            placeholder='이름을 입력하세요.'
+            className='h-[38px] w-[200px] rounded-[5px] border-[1px] border-subfont px-[10px] py-[10px] focus:border-focusColor focus:outline-none'
+          />
+        </div>
+        <div className='flex w-full items-center justify-between text-sm'>
+          <p>예약자 전화번호</p>
+          <input
+            type='text'
+            placeholder='전화번호를 입력하세요.'
+            className='h-[38px] w-[200px] rounded-[5px] border-[1px] border-subfont px-[10px] py-[10px] focus:border-focusColor focus:outline-none'
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationInfo;

--- a/src/pages/PaymentPage/components/ReservationInfo.tsx
+++ b/src/pages/PaymentPage/components/ReservationInfo.tsx
@@ -1,10 +1,9 @@
+import DetailTitle from '@components/DetailTitle';
+
 const ReservationInfo = () => {
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <div>
-        <p>예약자 정보</p>
-        <hr className='mt-2 border border-black' />
-      </div>
+      <DetailTitle title='예약자 정보' />
       <div className='flex w-custom flex-col gap-[10px]'>
         <div className='flex w-full items-center justify-between text-sm'>
           <p>예약자명</p>

--- a/src/pages/PaymentPage/components/ReservationPrice.tsx
+++ b/src/pages/PaymentPage/components/ReservationPrice.tsx
@@ -1,10 +1,9 @@
+import DetailTitle from '@components/DetailTitle';
+
 const ReservationPrice = () => {
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <div>
-        <p>주문 상품</p>
-        <hr className='mt-2 border border-black' />
-      </div>
+      <DetailTitle title='주문 상품' />
       <div>
         <div className='flex flex-col gap-[14px]'>
           <p className='font-normal'>ROOM A</p>

--- a/src/pages/PaymentPage/components/ReservationPrice.tsx
+++ b/src/pages/PaymentPage/components/ReservationPrice.tsx
@@ -1,0 +1,43 @@
+const ReservationPrice = () => {
+  return (
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <div>
+        <p>주문 상품</p>
+        <hr className='mt-2 border border-black' />
+      </div>
+      <div>
+        <div className='flex flex-col gap-[14px]'>
+          <p className='font-normal'>ROOM A</p>
+          <div className='flex flex-col gap-1'>
+            <div className='flex items-center justify-between text-sm'>
+              <div className='flex gap-1'>
+                <span>3,500</span>
+                <span>X</span>
+                <span>4인</span>
+              </div>
+              <div className='font-normal'>
+                14,000<span> 원</span>
+              </div>
+            </div>
+            <div className='flex items-center justify-between text-sm'>
+              <div className='flex'>
+                <span>3</span>
+                <span>시간 이용</span>
+              </div>
+              <div className='font-normal'>
+                42,000<span> 원</span>
+              </div>
+            </div>
+          </div>
+          <hr className='text-subfont' />
+          <div className='flex items-center justify-between font-normal'>
+            <span>총 결제 금액</span>
+            <span className='text-primary'>42,000원</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationPrice;

--- a/src/pages/PaymentPage/index.tsx
+++ b/src/pages/PaymentPage/index.tsx
@@ -1,0 +1,36 @@
+import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
+import MainLayout from '@layouts/MainLayout';
+import PaymentRoomCard from './components/PaymentRoomCard';
+import ReservationInfo from './components/ReservationInfo';
+import CancelRule from './components/CancelRule';
+import ReservationGuide from './components/ReservationGuide';
+import ReservationPrice from './components/ReservationPrice';
+import PaymentAgree from './components/PaymentAgree';
+
+const PaymentPage = () => {
+  return (
+    <>
+      <MainLayout>
+        <HeaderOnlyTitle title='예약 확인 및 결제' />
+        <div className='flex h-auto flex-col gap-4 pb-[110px]'>
+          <PaymentRoomCard />
+          <ReservationInfo />
+          <CancelRule />
+          <ReservationGuide />
+          <ReservationPrice />
+          <PaymentAgree />
+        </div>
+        <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>
+          <button
+            type='button'
+            className='btn-primary'
+          >
+            42,000원 결제하기
+          </button>
+        </div>
+      </MainLayout>
+    </>
+  );
+};
+
+export default PaymentPage;

--- a/src/pages/ReservationPage/components/RoomDetail.tsx
+++ b/src/pages/ReservationPage/components/RoomDetail.tsx
@@ -1,19 +1,17 @@
+import DetailTitle from '@components/DetailTitle';
 import { GrNext } from 'react-icons/gr';
 
 const RoomDetail = () => {
   return (
-    <div className='mx-auto mt-8 flex w-custom flex-col'>
-      <div className='flex items-center justify-between'>
-        <p>룸 상세 정보</p>
+    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
+      <DetailTitle title='룸 상세 정보'>
         <button
           type='button'
           className='flex items-center justify-center gap-1 text-xs text-subfont'
         >
           123 스터디룸 <GrNext />
         </button>
-      </div>
-
-      <hr className='my-2 border border-black' />
+      </DetailTitle>
       <div className='whitespace-pre-wrap text-sm'>
         강서구 내발산동 수명산파크 중심상가에 위치해있으며, 김포공항, 마곡,
         마곡나루, 우장산, 화곡역 등에 가깝고 대로변에 위치하고 있어 접근성이

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -19,6 +19,7 @@ import AddRoom from '@pages/AddRoom';
 import SearchResult from '@pages/SearchResult';
 import ReservationPage from '@pages/ReservationPage';
 import HostNotiPage from '@pages/HostNotiPage';
+import PaymentPage from '@pages/PaymentPage';
 
 const router = createBrowserRouter([
   {
@@ -100,6 +101,10 @@ const router = createBrowserRouter([
   {
     path: '/reservation',
     element: <ReservationPage />,
+  },
+  {
+    path: '/payment',
+    element: <PaymentPage />,
   },
   {
     path: '*',


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 결제페이지 마크업 구현 완료

## 📝 요구 사항과 구현 내용
- 스터디룸 정보 / 예약자 정보 입력 / 주문 상품 정보 / 이외 동의 체크 등 마크업 구현 완료
- 타이틀, checkbox 공통 컴포넌트로 분리
- 전화번호 입력 자동 하이픈 구현

## 💬 PR 포인트 & 궁금한 점
- 다음과 같은 타이틀 제 페이지 쪽에서 많이 쓰여서 공통 컴포넌트로 분리했습니다!
<img width="392" alt="스크린샷 2024-11-24 오전 11 36 30" src="https://github.com/user-attachments/assets/3d2a18d6-018c-4875-8a37-ba55ba8a3b50">

- 예약자 성함 및 전화번호 미입력 또는 정규식 불일치 시 처리는 추후에 할 예정입니다 !
- 개인정보 동의 상세보기에 관한 내용은 좀 더 생각해보고 추후 마크업 구현하겠습니다,,, 