### PR TITLE
✨ Feat : 회원가입/로그인/프리사인드 api 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,13 +1,55 @@
-import { defaultInstance } from '.';
+import { removeAuthToken, setAuthToken } from '@utils/auth';
+import { tokenInstance } from '.';
+
+interface UserSignUpData {
+  nickName: string;
+  phoneNumber: string;
+  sex: string;
+  email: string;
+  pwd: string;
+  birthDay: string;
+}
 
 interface LoginData {
   email: string;
   password: string;
 }
 
-export const postLogin = async (user: LoginData) => {
-  const response = await defaultInstance.post(`/api/v1/member/login`, user);
-  return response.data;
+interface BusinessSignUpData {
+  businessName: string;
+  businessEmail: string;
+  businessPwd: string;
+  businessNum: string;
+}
+
+// 사용자 회원가입
+export const postUserSignUp = async (user: UserSignUpData): Promise<void> => {
+  await tokenInstance.post('/api/v1/member/siginup', user);
 };
 
-export default postLogin;
+// 사용자 로그인
+export const postUserLogin = async (user: LoginData): Promise<void> => {
+  const response = await tokenInstance.post('/login/member', user);
+  const { accessToken } = response.data;
+  setAuthToken(accessToken);
+};
+
+// 사업자 회원가입
+export const postBusinessSignUp = async (
+  business: BusinessSignUpData,
+): Promise<void> => {
+  await tokenInstance.post('/api/v1/business/siginup', business);
+};
+
+// 사업자 로그인
+export const postBusinessLogin = async (business: LoginData): Promise<void> => {
+  const response = await tokenInstance.post('/login/business', business);
+  const { accessToken } = response.data;
+  setAuthToken(accessToken);
+};
+
+// 로그아웃
+export const postLogOut = async (): Promise<void> => {
+  removeAuthToken();
+  await tokenInstance.post('/logout');
+};

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -75,6 +75,12 @@ interface GetBusinessWorkPlaceData {
   workplaces: GetWorkPlaceData[];
 }
 
+// 프리사인드 URL 얻기
+export const getS3URL = async (): Promise<string> => {
+  const response = await authInstance.get('/api/generate-presigned-url');
+  return response.data;
+};
+
 // 스터디룸 등록
 export const postStudyRoom = async (
   studyroom: StudyRoomData,

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,10 +1,14 @@
+const setAuthToken = (accessToken: string) => {
+  localStorage.setItem('accessToken', accessToken);
+};
+
 const getAuthToken = () => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('accessToken');
   return token;
 };
 
 const removeAuthToken = () => {
-  localStorage.removeItem('token');
+  localStorage.removeItem('accessToken');
 };
 
-export { getAuthToken, removeAuthToken };
+export { setAuthToken, getAuthToken, removeAuthToken };


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 회원가입/로그인/프리사인드 api 구현

## 📝 요구 사항과 구현 내용
- 사용자 및 사업자 회원가입 api
- 사용자 및 사업자 로그인 api
- refresh Token으로 accessToken 갱신
- 로그아웃
- 프리사인드 url 받아오는 api (workplace.ts에  했습니다!)

## 💬 PR 포인트 & 궁금한 점
- 아까 혹시 몰라서 우선 tokenInstance를 새로 만든건데,, 다 만들고 생각해보니 tokenInstance의 response interceptor로 구현한 내용이 토큰 갱신 내용이라서, authInstance에도 필요하더라구요? 그래서 그냥 authInstance로 합쳐도 될 거 같습니다! 다들 동의하시면 내일 합치는 걸로 수정할게용
