### PR TITLE
✨ Feat : 사업자, 사용자 마이페이지 api 연결 완료

### DIFF
--- a/src/apis/reservation.ts
+++ b/src/apis/reservation.ts
@@ -10,12 +10,8 @@ export const postReservation = async (
 };
 
 // 사용자의 최근 예약 전체 조회
-export const getAllReservation = async (
-  memberId: number,
-): Promise<GetAllReservationData> => {
-  const response = await authInstance.get(
-    `api/v1/reservations/member/${memberId}`,
-  );
+export const getAllReservation = async (): Promise<GetAllReservationData> => {
+  const response = await authInstance.get(`api/v1/reservations/member`);
   return response.data;
 };
 

--- a/src/pages/HostMypage/components/HostButtonContainer.tsx
+++ b/src/pages/HostMypage/components/HostButtonContainer.tsx
@@ -1,13 +1,37 @@
 import CategoryButton from '@pages/UserMypage/components/CategoryButton';
 import LogoutButton from '@components/LogoutButton';
+import { useNavigate } from 'react-router-dom';
 import HostCategoryButton from './HostCategoryButton';
 
 const HostButtonContainer = () => {
+  const navigate = useNavigate();
+
+  const handleMoveBusinessInfo = () => {
+    navigate('/host-info');
+  };
+
+  const handleMoveReserverList = () => {
+    navigate('/management-reserver-list');
+  };
+
+  const handleMoveWorkplaceList = () => {
+    navigate('/management-place-list');
+  };
+
   return (
     <div className='absolute top-[290px] flex w-[330px] flex-col gap-[18px]'>
-      <HostCategoryButton category='예약자 확인' />
-      <HostCategoryButton category='사업장 관리' />
-      <CategoryButton category='회원 정보' />
+      <HostCategoryButton
+        category='예약자 확인'
+        onClickFunction={handleMoveReserverList}
+      />
+      <HostCategoryButton
+        category='사업장 관리'
+        onClickFunction={handleMoveWorkplaceList}
+      />
+      <CategoryButton
+        category='회원 정보'
+        onClickFunction={handleMoveBusinessInfo}
+      />
       <LogoutButton />
     </div>
   );

--- a/src/pages/HostMypage/components/HostCategoryButton.tsx
+++ b/src/pages/HostMypage/components/HostCategoryButton.tsx
@@ -1,11 +1,12 @@
 import { CategoryProps } from '@pages/UserMypage/components/CategoryButton';
 import { RiGroupLine, RiCommunityLine } from 'react-icons/ri';
 
-const HostCategoryButton = ({ category }: CategoryProps) => {
+const HostCategoryButton = ({ category, onClickFunction }: CategoryProps) => {
   return (
     <button
       type='button'
       className='flex h-[136px] w-[330px] flex-col justify-end gap-[10px] rounded-[10px] bg-white px-[16px] py-[20px] text-[18px] font-normal shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+      onClick={onClickFunction}
     >
       {category === '예약자 확인' ? (
         <RiGroupLine className='h-[30px] w-[30px] text-primary' />

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -1,15 +1,33 @@
-const host = {
-  name: 'HOST',
-  email: 'host@gmail.com',
-};
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useGetBusinessData from '../hooks/useGetBusinessData';
 
 const HostInfo = () => {
+  const { data, isLoading, isError } = useGetBusinessData();
+  const navigate = useNavigate();
+
+  // 렌더링 이후 데이터가 없고, 로딩중이 아니면 로그인 페이지로 이동
+  useEffect(() => {
+    if (!data && !isLoading) {
+      navigate('/login/business');
+    }
+  });
+
+  if (isLoading) {
+    return <p>로딩중...</p>;
+  }
+  if (isError) {
+    return <p>404</p>;
+  }
+
   return (
     <div className='self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-bold leading-none text-white'>
-        {host.name}
+        {data?.businessName || '닉네임을 불러올 수 없습니다.'}
       </div>
-      <div className='pt-0 text-[14px] text-white'>{host.email}</div>
+      <div className='pt-0 text-[14px] text-white'>
+        {data?.businessEmail || '이메일을 불러올 수 없습니다.'}
+      </div>
     </div>
   );
 };

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -9,7 +9,7 @@ const HostInfo = () => {
     <div className='flex flex-col gap-1 self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-bold leading-none text-white'>
         {data?.businessName || (
-          <p className='text-xl'>닉네임을 불러올 수 없습니다.</p>
+          <p className='text-2xl'>닉네임을 불러올 수 없습니다.</p>
         )}
       </div>
       <div className='pt-0 text-[14px] text-white'>

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -1,16 +1,9 @@
 import useGetBusinessData from '../hooks/useGetBusinessData';
 
 const HostInfo = () => {
-  const { data, isLoading, isError } = useGetBusinessData();
+  const { data } = useGetBusinessData();
 
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
-
-  if (isLoading) {
-    return <p>로딩중...</p>;
-  }
-  if (isError) {
-    return <p>404</p>;
-  }
 
   return (
     <div className='self-start pl-[33px] pt-[30px]'>

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -1,17 +1,9 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useGetBusinessData from '../hooks/useGetBusinessData';
 
 const HostInfo = () => {
   const { data, isLoading, isError } = useGetBusinessData();
-  const navigate = useNavigate();
 
-  // 렌더링 이후 데이터가 없고, 로딩중이 아니면 로그인 페이지로 이동
-  useEffect(() => {
-    if (!data && !isLoading) {
-      navigate('/login/business');
-    }
-  });
+  // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   if (isLoading) {
     return <p>로딩중...</p>;

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -6,12 +6,14 @@ const HostInfo = () => {
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
-    <div className='self-start pl-[33px] pt-[30px]'>
+    <div className='flex flex-col gap-1 self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-bold leading-none text-white'>
-        {data?.businessName || '닉네임을 불러올 수 없습니다.'}
+        {data?.businessName || (
+          <p className='text-xl'>닉네임을 불러올 수 없습니다.</p>
+        )}
       </div>
       <div className='pt-0 text-[14px] text-white'>
-        {data?.businessEmail || '이메일을 불러올 수 없습니다.'}
+        {data?.businessEmail || <p>이메일을 불러올 수 없습니다.</p>}
       </div>
     </div>
   );

--- a/src/pages/HostMypage/hooks/useGetBusinessData.ts
+++ b/src/pages/HostMypage/hooks/useGetBusinessData.ts
@@ -1,0 +1,12 @@
+import { getBusinessData } from '@apis/business';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetBusinessData = () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['business'],
+    queryFn: () => getBusinessData(),
+  });
+  return { data, isLoading, isError };
+};
+
+export default useGetBusinessData;

--- a/src/pages/HostMypage/hooks/useGetBusinessData.ts
+++ b/src/pages/HostMypage/hooks/useGetBusinessData.ts
@@ -2,11 +2,11 @@ import { getBusinessData } from '@apis/business';
 import { useQuery } from '@tanstack/react-query';
 
 const useGetBusinessData = () => {
-  const { data, isLoading, isError } = useQuery({
+  const { data } = useQuery({
     queryKey: ['business'],
     queryFn: () => getBusinessData(),
   });
-  return { data, isLoading, isError };
+  return { data };
 };
 
 export default useGetBusinessData;

--- a/src/pages/UserMypage/components/CategoryButton.tsx
+++ b/src/pages/UserMypage/components/CategoryButton.tsx
@@ -2,13 +2,15 @@ import { MdArrowForwardIos } from 'react-icons/md';
 
 export interface CategoryProps {
   category: string;
+  onClickFunction: () => void;
 }
 
-const CategoryButton = ({ category }: CategoryProps) => {
+const CategoryButton = ({ category, onClickFunction }: CategoryProps) => {
   return (
     <button
       type='button'
-      className='flex h-[49px] items-center justify-between rounded-[10px] bg-white px-[16px] py-[9px] text-[14px] font-normal shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+      className='flex h-[49px] w-[330px] items-center justify-between rounded-[10px] bg-white px-[16px] py-[9px] text-[14px] font-normal shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'
+      onClick={onClickFunction}
     >
       {category}
       <MdArrowForwardIos />

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -1,26 +1,10 @@
 import ListStyle from '@components/ListStyle';
+import { GetAllReservation } from '@typings/types';
+import { getStringFromDate, getStringFromDateTime } from '@utils/formatTime';
 
-interface Reservation {
-  name: string;
-  date: string;
-  time: string;
-  room: string;
-  people: number;
-  price: number;
-}
-
-const latestReservationCard: Reservation = {
-  name: 'ABC스터디룸',
-  date: '2024.06.08',
-  time: '14:00',
-  room: 'ROOM A',
-  people: 4,
-  price: 8000,
-};
-
-const LatestReservation = () => {
+const LatestReservation = ({ data }: { data: GetAllReservation }) => {
   return (
-    <div className='flex h-auto w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
+    <div className='flex h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
       <div className='flex items-center gap-[18px]'>
         <img
           src='https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg'
@@ -29,34 +13,29 @@ const LatestReservation = () => {
         />
 
         <div className='flex w-[auto] flex-col gap-[7px]'>
-          <p className='text-[16px] font-medium'>
-            {latestReservationCard.name}
-          </p>
+          <p className='text-[16px] font-medium'>{data.workplaceName}</p>
           <ul className='flex flex-col gap-[2px] text-[12px]'>
             <ListStyle
               name='예약일'
-              value={latestReservationCard.date}
+              value={getStringFromDate(data.startTime)}
             />
             <ListStyle
               name='예약시간'
-              value={latestReservationCard.time}
+              value={`${getStringFromDateTime(data.startTime)} ~ ${getStringFromDateTime(data.endTime)}`}
             />
-            <ListStyle
+            {/* <ListStyle
               name='예약된 룸'
               value={latestReservationCard.room}
-            />
+            /> */}
             <ListStyle
               name='인원'
-              value={`${latestReservationCard.people}인`}
+              value={`${data.studyRoomCapacity} 인`}
             />
           </ul>
         </div>
       </div>
       <span className='self-end text-[14px] font-normal'>
-        {latestReservationCard.price
-          .toString()
-          .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-        원
+        {data.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}원
       </span>
     </div>
   );

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -3,8 +3,10 @@ import LogoutButton from '@components/LogoutButton';
 import { useNavigate } from 'react-router-dom';
 import LatestReservation from './LatestReservation';
 import CategoryButton from './CategoryButton';
+import { useGetLatestReservation } from '../hooks/useGetMyReservations';
 
 const UserButtonContainer = () => {
+  const latestReservation = useGetLatestReservation();
   const navigate = useNavigate();
 
   const handleMoveReservationList = () => {
@@ -30,7 +32,15 @@ const UserButtonContainer = () => {
           예약 내역
           <MdArrowForwardIos />
         </button>
-        <LatestReservation />
+        {latestReservation ? (
+          <LatestReservation data={latestReservation} />
+        ) : (
+          <div className='flex h-[172px] w-[330px] items-center justify-center rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
+            <p className='text-sm font-normal text-subfont'>
+              예약 내역이 없습니다.
+            </p>
+          </div>
+        )}
       </div>
       <CategoryButton
         category='리뷰 관리'

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -7,6 +7,10 @@ import CategoryButton from './CategoryButton';
 const UserButtonContainer = () => {
   const navigate = useNavigate();
 
+  const handleMoveReservationList = () => {
+    navigate('/reservation-list');
+  };
+
   const handleMoveReviewList = () => {
     navigate('/review-list');
   };
@@ -21,6 +25,7 @@ const UserButtonContainer = () => {
         <button
           type='button'
           className='flex items-center gap-[2px] self-end text-[14px] text-white'
+          onClick={handleMoveReservationList}
         >
           예약 내역
           <MdArrowForwardIos />

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -1,9 +1,20 @@
 import { MdArrowForwardIos } from 'react-icons/md';
 import LogoutButton from '@components/LogoutButton';
+import { useNavigate } from 'react-router-dom';
 import LatestReservation from './LatestReservation';
 import CategoryButton from './CategoryButton';
 
 const UserButtonContainer = () => {
+  const navigate = useNavigate();
+
+  const handleMoveReviewList = () => {
+    navigate('/review-list');
+  };
+
+  const handleMoveUserInfo = () => {
+    navigate('/user-info');
+  };
+
   return (
     <div className='absolute top-[255px] flex w-[330px] flex-col gap-[18px]'>
       <div className='flex flex-col gap-[10px]'>
@@ -16,8 +27,14 @@ const UserButtonContainer = () => {
         </button>
         <LatestReservation />
       </div>
-      <CategoryButton category='리뷰 관리' />
-      <CategoryButton category='회원 정보' />
+      <CategoryButton
+        category='리뷰 관리'
+        onClickFunction={handleMoveReviewList}
+      />
+      <CategoryButton
+        category='회원 정보'
+        onClickFunction={handleMoveUserInfo}
+      />
       <LogoutButton />
     </div>
   );

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -1,17 +1,10 @@
 import useGetUserData from '../hooks/useGetUserData';
 
 const UserInfo = () => {
-  const { data, isLoading, isError } = useGetUserData();
+  const { data } = useGetUserData();
   // const navigate = useNavigate();
 
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
-
-  if (isLoading) {
-    return <p>로딩중...</p>;
-  }
-  if (isError) {
-    return <p>404</p>;
-  }
 
   return (
     <div className='self-start pl-[33px] pt-[30px]'>

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -7,12 +7,14 @@ const UserInfo = () => {
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
-    <div className='self-start pl-[33px] pt-[30px]'>
+    <div className='flex flex-col gap-1 self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-semibold leading-none text-white'>
-        {data?.nickName || '닉네임을 불러올 수 없습니다.'}
+        {data?.nickName || (
+          <p className='text-xl'>닉네임을 불러올 수 없습니다.</p>
+        )}
       </div>
       <div className='pt-0 text-[14px] text-white'>
-        {data?.email || '이메일을 불러올 수 없습니다.'}
+        {data?.email || <p>이메일을 불러올 수 없습니다.</p>}
       </div>
     </div>
   );

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -1,15 +1,33 @@
-const user = {
-  name: 'HYUN',
-  email: 'hyun@gmail.com',
-};
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useGetUserData from '../hooks/useGetUserData';
 
 const UserInfo = () => {
+  const { data, isLoading, isError } = useGetUserData();
+  const navigate = useNavigate();
+
+  // 렌더링 이후 데이터가 없고, 로딩중이 아니면 로그인 페이지로 이동
+  useEffect(() => {
+    if (!data && !isLoading) {
+      navigate('/login/user');
+    }
+  });
+
+  if (isLoading) {
+    return <p>로딩중...</p>;
+  }
+  if (isError) {
+    return <p>404</p>;
+  }
+
   return (
     <div className='self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-semibold leading-none text-white'>
-        {user.name}
+        {data?.nickName || '닉네임을 불러올 수 없습니다.'}
       </div>
-      <div className='pt-0 text-[14px] text-white'>{user.email}</div>
+      <div className='pt-0 text-[14px] text-white'>
+        {data?.email || '이메일을 불러올 수 없습니다.'}
+      </div>
     </div>
   );
 };

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -1,17 +1,10 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useGetUserData from '../hooks/useGetUserData';
 
 const UserInfo = () => {
   const { data, isLoading, isError } = useGetUserData();
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
-  // 렌더링 이후 데이터가 없고, 로딩중이 아니면 로그인 페이지로 이동
-  useEffect(() => {
-    if (!data && !isLoading) {
-      navigate('/login/user');
-    }
-  });
+  // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   if (isLoading) {
     return <p>로딩중...</p>;

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -10,7 +10,7 @@ const UserInfo = () => {
     <div className='flex flex-col gap-1 self-start pl-[33px] pt-[30px]'>
       <div className='text-[32px] font-semibold leading-none text-white'>
         {data?.nickName || (
-          <p className='text-xl'>닉네임을 불러올 수 없습니다.</p>
+          <p className='text-2xl'>닉네임을 불러올 수 없습니다.</p>
         )}
       </div>
       <div className='pt-0 text-[14px] text-white'>

--- a/src/pages/UserMypage/hooks/useGetMyReservations.ts
+++ b/src/pages/UserMypage/hooks/useGetMyReservations.ts
@@ -1,14 +1,19 @@
 import { getAllReservation } from '@apis/reservation';
 import { useQuery } from '@tanstack/react-query';
 
-const useGetAllReservations = () => {
+// 모든 예약 정보 불러오기
+export const useGetAllReservations = () => {
   const { data } = useQuery({
-    queryKey: ['latestReservation'],
+    queryKey: ['myReservationList'],
     queryFn: () => getAllReservation(),
   });
   return { data };
 };
 
-const useGetLatestReservation = () => {
+// 최근 예약 내역 한 건 불러오기
+export const useGetLatestReservation = () => {
   const { data } = useGetAllReservations();
+  const latestReservationData = data?.reservations[0];
+
+  return latestReservationData;
 };

--- a/src/pages/UserMypage/hooks/useGetMyReservations.ts
+++ b/src/pages/UserMypage/hooks/useGetMyReservations.ts
@@ -1,0 +1,14 @@
+import { getAllReservation } from '@apis/reservation';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetAllReservations = () => {
+  const { data } = useQuery({
+    queryKey: ['latestReservation'],
+    queryFn: () => getAllReservation(),
+  });
+  return { data };
+};
+
+const useGetLatestReservation = () => {
+  const { data } = useGetAllReservations();
+};

--- a/src/pages/UserMypage/hooks/useGetUserData.ts
+++ b/src/pages/UserMypage/hooks/useGetUserData.ts
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { Member } from '@typings/types';
 
 const useGetUserData = () => {
-  const { data, isLoading, isError } = useQuery<Member>({
+  const { data } = useQuery<Member>({
     queryKey: ['member'],
     queryFn: () => getUserData(),
   });
-  return { data, isLoading, isError };
+  return { data };
 };
 
 export default useGetUserData;

--- a/src/pages/UserMypage/hooks/useGetUserData.ts
+++ b/src/pages/UserMypage/hooks/useGetUserData.ts
@@ -1,0 +1,13 @@
+import { getUserData } from '@apis/member';
+import { useQuery } from '@tanstack/react-query';
+import { Member } from '@typings/types';
+
+const useGetUserData = () => {
+  const { data, isLoading, isError } = useQuery<Member>({
+    queryKey: ['member'],
+    queryFn: () => getUserData(),
+  });
+  return { data, isLoading, isError };
+};
+
+export default useGetUserData;

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -10,10 +10,29 @@ export const getDateFunction = (timeString: string) => {
   return dateString;
 };
 
+// date타입에서 YYYY-MM-DD 추출해 YYYY.MM.DD로 변환
+export const getStringFromDate = (value: Date) => {
+  const year = value.getFullYear();
+  const month = (value.getMonth() + 1).toString().padStart(2, '0');
+  const day = value.getDate().toString().padStart(2, '0');
+  const dateString = `${year}.${month}.${day}`;
+
+  return dateString;
+};
+
 // YYYY-MM-DDTHH:mm:ss 에서 시간(HH:mm) 추출
 export const getTimeFunction = (timeString: string) => {
   const hour = new Date(timeString).getHours().toString().padStart(2, '0');
   const minutes = new Date(timeString).getMinutes().toString().padStart(2, '0');
+  const formattedTimeString = `${hour}:${minutes}`;
+
+  return formattedTimeString;
+};
+
+// date타입에서 시간(HH:mm) 추출
+export const getStringFromDateTime = (value: Date) => {
+  const hour = value.getHours().toString().padStart(2, '0');
+  const minutes = value.getMinutes().toString().padStart(2, '0');
   const formattedTimeString = `${hour}:${minutes}`;
 
   return formattedTimeString;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업자, 사용자 마이페이지 api 연결 완료

## 📝 요구 사항과 구현 내용
- 사업자 마이페이지 사업자 정보 받아오기
- 사용자 마이페이지 사용자 정보 받아오기
- 사업자, 사용자 마이페이지 카테고리별 navigate 추가
- 정보 undefined일 때 띄워줄 문구 추가
- date타입 변환 formatted 함수 추가

## ✅ 피드백 반영사항
- 사용자의 최근 예약 전체 조회에서 api memberId 삭제
  백엔드측 확정 후 변경 필요

## 💬 PR 포인트 & 궁금한 점
- 로그인 후 테스트 필요