### PR TITLE
✨ Feat : 사업장 관리 페이지 기능 구현 

### DIFF
--- a/src/components/ListStyle.tsx
+++ b/src/components/ListStyle.tsx
@@ -6,8 +6,8 @@ interface ListProps {
 const ListStyle = ({ name, value }: ListProps) => {
   return (
     <li className='flex gap-[12px]'>
-      <p className='w-[46px]'>{name}</p>
-      <span className='font-normal'>{value}</span>
+      <p className='w-[48px]'>{name}</p>
+      <span className='w-[170px] break-keep font-normal'>{value}</span>
     </li>
   );
 };

--- a/src/pages/DetailPage/hooks/useGetStudyroomOfWorkplace.ts
+++ b/src/pages/DetailPage/hooks/useGetStudyroomOfWorkplace.ts
@@ -3,7 +3,7 @@ import { getWorkplaceStudyRoom } from '../../../apis/workplace';
 
 const useGetStudyroomOfWorkplace = (workplaceId: number) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['studyroomOfWorkplace'],
+    queryKey: ['studyroomOfWorkplace', workplaceId],
     queryFn: () => getWorkplaceStudyRoom(workplaceId),
   });
   return { data, isLoading };

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -2,57 +2,85 @@ import { MdArrowForwardIos } from 'react-icons/md';
 import { getDateFunction } from '@utils/formatTime';
 import ButtonInCard from '@components/ButtonInCard';
 import ListStyle from '@components/ListStyle';
-import type { WorkPlace } from './ManagementPlaceList';
+import { GetWorkPlaceData } from '@typings/types';
+import { useState } from 'react';
+import Modal from '@components/Modal';
+import useDeleteBusinessPlace from '../hooks/useDeleteBusinessPlace';
 
-const ManagementPlaceCard = ({ item }: { item: WorkPlace }) => {
+const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
   const {
+    workplaceId,
     workplaceName,
     workplaceAddress,
-    workPlacePhoneNumber,
+    workplacePhoneNumber,
     createdAt,
-    numberOfRooms,
-    workplaceImage,
+    imageUrl,
   } = item;
 
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const { mutate: deleteMutation } = useDeleteBusinessPlace(workplaceId);
+
+  const handleDeleteBusinessWorkplace = () => {
+    deleteMutation();
+    setModalOpen(() => false);
+  };
+
   return (
-    <div className='mx-auto flex w-custom flex-col gap-2 border-b border-solid border-b-black px-[13px] py-[26px]'>
-      <div className='flex justify-between'>
-        <div className='flex flex-col items-start gap-2'>
-          <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-            {workplaceName}
-            <MdArrowForwardIos className='w-3' />
+    <>
+      <div className='mx-auto flex w-custom flex-col gap-4 border-b border-solid border-b-black px-[13px] py-[26px]'>
+        <div className='flex justify-between'>
+          <div className='flex flex-col items-start gap-2'>
+            <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
+              {workplaceName}
+              <MdArrowForwardIos className='w-3' />
+            </div>
+
+            <ul className='flex flex-col gap-1 text-[12px]'>
+              <ListStyle
+                name='주소'
+                value={workplaceAddress}
+              />
+              <ListStyle
+                name='전화번호'
+                value={workplacePhoneNumber}
+              />
+              <ListStyle
+                name='룸 수'
+                value={0}
+              />
+              <ListStyle
+                name='등록일'
+                value={getDateFunction(createdAt)}
+              />
+            </ul>
           </div>
-
-          <ul className='flex flex-col gap-1 text-[12px]'>
-            <ListStyle
-              name='주소'
-              value={workplaceAddress}
-            />
-            <ListStyle
-              name='전화번호'
-              value={workPlacePhoneNumber}
-            />
-            <ListStyle
-              name='룸 수'
-              value={numberOfRooms}
-            />
-            <ListStyle
-              name='등록일'
-              value={getDateFunction(createdAt)}
-            />
-          </ul>
+          <img
+            src={imageUrl}
+            alt='스터디룸 사진'
+            className='h-[50px] w-[50px] cursor-pointer object-cover'
+          />
         </div>
-        <img
-          src={workplaceImage}
-          alt='스터디룸 사진'
-          className='h-[50px] w-[50px] cursor-pointer object-cover'
-        />
+
+        <div className='self-end'>
+          <div className='flex gap-1'>
+            <ButtonInCard
+              name='삭제'
+              onClickFunction={() => setModalOpen(true)}
+            />
+            <ButtonInCard name='수정' />
+          </div>
+        </div>
       </div>
 
-      <div className='self-end'>
-        <ButtonInCard name='수정' />
-      </div>
-    </div>
+      {modalOpen && (
+        <Modal
+          message='사업장을 삭제하시겠습니까?'
+          onCancelButtonClick={() => setModalOpen(false)}
+          onConfirmButtonClick={handleDeleteBusinessWorkplace}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -5,6 +5,7 @@ import ListStyle from '@components/ListStyle';
 import { GetWorkPlaceData } from '@typings/types';
 import { useState } from 'react';
 import Modal from '@components/Modal';
+import { useNavigate } from 'react-router-dom';
 import useDeleteBusinessPlace from '../hooks/useDeleteBusinessPlace';
 
 const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
@@ -17,6 +18,7 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
     imageUrl,
   } = item;
 
+  const navigate = useNavigate();
   const [modalOpen, setModalOpen] = useState(false);
 
   const { mutate: deleteMutation } = useDeleteBusinessPlace(workplaceId);
@@ -24,6 +26,10 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
   const handleDeleteBusinessWorkplace = () => {
     deleteMutation();
     setModalOpen(() => false);
+  };
+
+  const handleMoveWorkplaceEditPage = (pageId: number) => {
+    navigate(`/modify-Space/${pageId}`);
   };
 
   return (
@@ -68,7 +74,10 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
               name='삭제'
               onClickFunction={() => setModalOpen(true)}
             />
-            <ButtonInCard name='수정' />
+            <ButtonInCard
+              name='수정'
+              onClickFunction={() => handleMoveWorkplaceEditPage(workplaceId)}
+            />
           </div>
         </div>
       </div>

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -5,10 +5,15 @@ import ListStyle from '@components/ListStyle';
 import { GetWorkPlaceData } from '@typings/types';
 import { useState } from 'react';
 import Modal from '@components/Modal';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import useDeleteBusinessPlace from '../hooks/useDeleteBusinessPlace';
+import { useGetNumberOfRooms } from '../hooks/useGetBusinessWorkplaces';
 
-const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
+interface ManagementPlaceCardProps {
+  item: GetWorkPlaceData;
+}
+
+const ManagementPlaceCard = ({ item }: ManagementPlaceCardProps) => {
   const {
     workplaceId,
     workplaceName,
@@ -21,13 +26,16 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
   const navigate = useNavigate();
   const [modalOpen, setModalOpen] = useState(false);
 
+  const numberOfRooms = useGetNumberOfRooms(workplaceId);
   const { mutate: deleteMutation } = useDeleteBusinessPlace(workplaceId);
 
+  // 사업장 삭제
   const handleDeleteBusinessWorkplace = () => {
     deleteMutation();
     setModalOpen(() => false);
   };
 
+  // 사업장 수정 페이지로 이동
   const handleMoveWorkplaceEditPage = (pageId: number) => {
     navigate(`/modify-Space/${pageId}`);
   };
@@ -37,10 +45,12 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
       <div className='mx-auto flex w-custom flex-col gap-4 border-b border-solid border-b-black px-[13px] py-[26px]'>
         <div className='flex justify-between'>
           <div className='flex flex-col items-start gap-2'>
-            <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-              {workplaceName}
-              <MdArrowForwardIos className='w-3' />
-            </div>
+            <Link to={`/detail/${workplaceId}`}>
+              <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
+                {workplaceName}
+                <MdArrowForwardIos className='w-3' />
+              </div>
+            </Link>
 
             <ul className='flex flex-col gap-1 text-[12px]'>
               <ListStyle
@@ -53,7 +63,7 @@ const ManagementPlaceCard = ({ item }: { item: GetWorkPlaceData }) => {
               />
               <ListStyle
                 name='룸 수'
-                value={0}
+                value={numberOfRooms}
               />
               <ListStyle
                 name='등록일'

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceList.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceList.tsx
@@ -1,49 +1,22 @@
 import { IoAdd } from 'react-icons/io5';
+import { useNavigate } from 'react-router-dom';
 import ManagementPlaceCard from './ManagementPlaceCard';
 import { useGetWorkplacesList } from '../hooks/useGetBusinessWorkplaces';
 
-// export interface WorkPlace {
-//   workPlaceId: number;
-//   workplaceName: string;
-//   workplaceAddress: string;
-//   workPlacePhoneNumber: string;
-//   createdAt: string;
-//   numberOfRooms: number;
-//   workplaceImage: string;
-// }
-
-// const workPlaceList: WorkPlace[] = [
-//   {
-//     workPlaceId: 1,
-//     workplaceName: '스터디랩',
-//     workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
-//     workPlacePhoneNumber: '031-111-2222',
-//     createdAt: '2024-06-07T13:02:34',
-//     numberOfRooms: 10,
-//     workplaceImage:
-//       'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
-//   },
-//   {
-//     workPlaceId: 2,
-//     workplaceName: 'ABC 스터디카페',
-//     workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
-//     workPlacePhoneNumber: '031-222-2222',
-//     createdAt: '2024-06-08T13:02:34',
-//     numberOfRooms: 17,
-//     workplaceImage:
-//       'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
-//   },
-// ];
-
 const ManagementPlaceList = () => {
+  const navigate = useNavigate();
   const workplaces = useGetWorkplacesList();
 
   const sortedWorkPlaceList = [...workplaces].sort((b, a) => {
     return +new Date(a.createdAt) - +new Date(b.createdAt);
   });
 
+  const handleAddBusinessPlace = () => {
+    navigate('/register-Space');
+  };
+
   return (
-    <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
+    <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
       {workplaces.length > 0 &&
         sortedWorkPlaceList.map((item) => {
           return (
@@ -57,6 +30,7 @@ const ManagementPlaceList = () => {
       <button
         type='button'
         className='group mx-auto my-6 flex h-32 w-custom flex-col items-center justify-center rounded-[8px] border border-dashed p-2 active:border-primary'
+        onClick={handleAddBusinessPlace}
       >
         <IoAdd className='text-6xl text-subfont group-active:text-primary' />
         <p className='text-sm text-subfont group-active:text-primary'>

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceList.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceList.tsx
@@ -1,51 +1,54 @@
 import { IoAdd } from 'react-icons/io5';
 import ManagementPlaceCard from './ManagementPlaceCard';
+import { useGetWorkplacesList } from '../hooks/useGetBusinessWorkplaces';
 
-export interface WorkPlace {
-  workPlaceId: number;
-  workplaceName: string;
-  workplaceAddress: string;
-  workPlacePhoneNumber: string;
-  createdAt: string;
-  numberOfRooms: number;
-  workplaceImage: string;
-}
+// export interface WorkPlace {
+//   workPlaceId: number;
+//   workplaceName: string;
+//   workplaceAddress: string;
+//   workPlacePhoneNumber: string;
+//   createdAt: string;
+//   numberOfRooms: number;
+//   workplaceImage: string;
+// }
 
-const workPlaceList: WorkPlace[] = [
-  {
-    workPlaceId: 1,
-    workplaceName: '스터디랩',
-    workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
-    workPlacePhoneNumber: '031-111-2222',
-    createdAt: '2024-06-07T13:02:34',
-    numberOfRooms: 10,
-    workplaceImage:
-      'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
-  },
-  {
-    workPlaceId: 2,
-    workplaceName: 'ABC 스터디카페',
-    workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
-    workPlacePhoneNumber: '031-222-2222',
-    createdAt: '2024-06-08T13:02:34',
-    numberOfRooms: 17,
-    workplaceImage:
-      'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
-  },
-];
+// const workPlaceList: WorkPlace[] = [
+//   {
+//     workPlaceId: 1,
+//     workplaceName: '스터디랩',
+//     workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
+//     workPlacePhoneNumber: '031-111-2222',
+//     createdAt: '2024-06-07T13:02:34',
+//     numberOfRooms: 10,
+//     workplaceImage:
+//       'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
+//   },
+//   {
+//     workPlaceId: 2,
+//     workplaceName: 'ABC 스터디카페',
+//     workplaceAddress: '경기 수원시 팔달구 권광로 274 2층',
+//     workPlacePhoneNumber: '031-222-2222',
+//     createdAt: '2024-06-08T13:02:34',
+//     numberOfRooms: 17,
+//     workplaceImage:
+//       'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg',
+//   },
+// ];
 
 const ManagementPlaceList = () => {
-  const sortedWorkPlaceList = [...workPlaceList].sort((b, a) => {
+  const workplaces = useGetWorkplacesList();
+
+  const sortedWorkPlaceList = [...workplaces].sort((b, a) => {
     return +new Date(a.createdAt) - +new Date(b.createdAt);
   });
 
   return (
     <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
-      {workPlaceList.length > 0 &&
+      {workplaces.length > 0 &&
         sortedWorkPlaceList.map((item) => {
           return (
             <ManagementPlaceCard
-              key={item.workPlaceId}
+              key={item.workplaceId}
               item={item}
             />
           );

--- a/src/pages/ManagementPlacePage/hooks/useDeleteBusinessPlace.ts
+++ b/src/pages/ManagementPlacePage/hooks/useDeleteBusinessPlace.ts
@@ -1,0 +1,17 @@
+import { deleteWorkPlace } from '@apis/workplace';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useDeleteBusinessPlace = (workplaceId: number) => {
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteWorkPlace(workplaceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['businessWorkplaces'] });
+    },
+  });
+
+  return deleteMutation;
+};
+
+export default useDeleteBusinessPlace;

--- a/src/pages/ManagementPlacePage/hooks/useGetBusinessWorkplaces.ts
+++ b/src/pages/ManagementPlacePage/hooks/useGetBusinessWorkplaces.ts
@@ -1,0 +1,17 @@
+import { getBusinessWorkPlace } from '@apis/workplace';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetBusinessWorkplaces = () => {
+  const { data } = useQuery({
+    queryKey: ['businessWorkplaces'],
+    queryFn: () => getBusinessWorkPlace(),
+  });
+  return { data };
+};
+
+export const useGetWorkplacesList = () => {
+  const { data } = useGetBusinessWorkplaces();
+  const workplaceList = data ? data.workplaces : [];
+
+  return workplaceList;
+};

--- a/src/pages/ManagementPlacePage/hooks/useGetBusinessWorkplaces.ts
+++ b/src/pages/ManagementPlacePage/hooks/useGetBusinessWorkplaces.ts
@@ -1,4 +1,5 @@
 import { getBusinessWorkPlace } from '@apis/workplace';
+import useGetStudyroomOfWorkplace from '@pages/DetailPage/hooks/useGetStudyroomOfWorkplace';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGetBusinessWorkplaces = () => {
@@ -7,6 +8,13 @@ export const useGetBusinessWorkplaces = () => {
     queryFn: () => getBusinessWorkPlace(),
   });
   return { data };
+};
+
+export const useGetNumberOfRooms = (workplaceId: number) => {
+  const { data } = useGetStudyroomOfWorkplace(workplaceId);
+  const numberOfRoom = data ? data.length : 0;
+
+  return numberOfRoom;
 };
 
 export const useGetWorkplacesList = () => {


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업장 관리 페이지 기능 구현 

## 📝 요구 사항과 구현 내용
- 사업자의 사업장 목록 불러오기
- 사업장 삭제 버튼 누르면 모달창 뜨고, 모달창에서 확인 버튼 누르면 사업장 삭제
- 사업장 수정 버튼 누르면 공간 수정 페이지로 이동
- 사업장 등록 버튼 누르면 공간 등록 페이지로 이동
- 사업장별 룸 수 반영
  src/pages/DetailPage/hooks/useGetStudyroomOfWorkplace.ts 파일에서 workplaceId마다 룸 수 다르게 받아오기 위해 workplaceId 추가
- ListStyle 컴포넌트에서 width 설정 및 단어 단위로 줄바꿈되도록 break-keep 추가
- 사업장 관리 페이지 하단 패딩값 pb-24 추가

## 🔗 연관된 이슈
- close #28 