### PR TITLE
✨ Feat : 수정 페이지 1차 및 토큰/role 저장

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import { removeAuthToken, setAuthToken } from '@utils/auth';
+import { removeAuthToken, setAuthToken, setRole } from '@utils/auth';
 import { BusinessSignUpData, LoginData, UserSignUpData } from '@typings/types';
 import { authInstance, defaultInstance } from '.';
 
@@ -12,8 +12,10 @@ export const postUserLogin = async (user: LoginData): Promise<void> => {
   const response = await defaultInstance.post('/login/member', user, {
     withCredentials: true,
   });
-  const { token } = response.data;
+  const token = response.headers.authorization;
   setAuthToken(token);
+  const { role } = response.data;
+  setRole(role);
 };
 
 // 사업자 회원가입
@@ -28,8 +30,10 @@ export const postBusinessLogin = async (business: LoginData): Promise<void> => {
   const response = await defaultInstance.post('/login/business', business, {
     withCredentials: true,
   });
-  const { token } = response.data;
+  const token = response.headers.authorization;
   setAuthToken(token);
+  const { role } = response.data;
+  setRole(role);
 };
 
 // 로그아웃

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -40,7 +40,7 @@ authInstance.interceptors.response.use(
         const response = await authInstance.post('/reissue');
 
         if (response.status === 200) {
-          const { token } = response.data;
+          const token = response.headers.authorization;
           setAuthToken(token);
 
           const originalRequest = error.config as AxiosRequestConfig;

--- a/src/pages/AddRoom/components/RoomForm.tsx
+++ b/src/pages/AddRoom/components/RoomForm.tsx
@@ -8,9 +8,15 @@ interface RoomFormProps {
   room: Room;
   updateRoomData: (data: Partial<Room>) => void;
   completeAdd: (id: string) => void;
+  modify: boolean;
 }
 
-const RoomForm = ({ room, updateRoomData, completeAdd }: RoomFormProps) => {
+const RoomForm = ({
+  room,
+  updateRoomData,
+  completeAdd,
+  modify,
+}: RoomFormProps) => {
   const handleChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
@@ -160,7 +166,7 @@ const RoomForm = ({ room, updateRoomData, completeAdd }: RoomFormProps) => {
           type='submit'
           className='btn-primary mt-[40px] text-[16px]'
         >
-          룸 등록 완료
+          {modify ? '완료' : '룸 등록 완료'}
         </button>
       </form>
     </div>

--- a/src/pages/ModifySpace/hooks/useGetRoomListInfo.ts
+++ b/src/pages/ModifySpace/hooks/useGetRoomListInfo.ts
@@ -1,0 +1,11 @@
+import { getWorkplaceStudyRoom } from '@apis/workplace';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetRoomListInfo = (workplaceId: number) => {
+  return useQuery({
+    queryKey: ['roomList', workplaceId],
+    queryFn: () => getWorkplaceStudyRoom(workplaceId),
+  });
+};
+
+export default useGetRoomListInfo;

--- a/src/pages/ModifySpace/hooks/useGetWorkPlaceInfo.ts
+++ b/src/pages/ModifySpace/hooks/useGetWorkPlaceInfo.ts
@@ -1,0 +1,11 @@
+import { getWorkPlace } from '@apis/workplace';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetWorkPlaceInfo = (workplaceId: number) => {
+  return useQuery({
+    queryKey: ['workplaceInfo', workplaceId],
+    queryFn: () => getWorkPlace(workplaceId),
+  });
+};
+
+export default useGetWorkPlaceInfo;

--- a/src/pages/ModifySpace/index.tsx
+++ b/src/pages/ModifySpace/index.tsx
@@ -1,0 +1,134 @@
+import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
+import MainLayout from '@layouts/MainLayout';
+import { useCallback, useEffect, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { Room, Space, StudyRoomData } from '@typings/types';
+import SpaceForm from '@pages/RegisterSpace/components/SpaceForm';
+import { useParams } from 'react-router-dom';
+import RoomForm from '../AddRoom/components/RoomForm';
+import useGetWorkPlaceInfo from './hooks/useGetWorkPlaceInfo';
+import useGetRoomListInfo from './hooks/useGetRoomListInfo';
+
+const ModifySpace = () => {
+  const { workplaceId } = useParams() as { workplaceId: string };
+  const { data: info } = useGetWorkPlaceInfo(Number(workplaceId));
+  const { data: roomInfo } = useGetRoomListInfo(Number(workplaceId));
+  console.log(info);
+  console.log(roomInfo);
+  const modify = true;
+
+  // 공간 등록 + 룸 폼 상태관리
+  const [spaceFormData, setSpaceFormData] = useState<Space>({
+    spaceName: '',
+    description: '',
+    openTime: '선택',
+    closedTime: '선택',
+    phoneNumber: '',
+    address: {
+      basic: '',
+      detail: '',
+    },
+    spaceImage: null,
+    rooms: [],
+  });
+
+  useEffect(() => {
+    if (info && roomInfo) {
+      const [basic, ...detailParts] = info.workplaceAddress.split(',');
+      const roomList = roomInfo.map((room: StudyRoomData) => ({
+        id: String(room.id),
+        roomName: room.title,
+        description: room.description,
+        price: String(room.price),
+        people: room.capacity,
+        roomImages: [{ url: room.imageUrl, file: new File([], room.imageUrl) }],
+      }));
+
+      setSpaceFormData((prev) => ({
+        ...prev,
+        spaceName: info.workplaceName,
+        description: info.workplaceDescription,
+        openTime: info.workplaceStartTime,
+        closedTime: info.workplaceEndTime,
+        phoneNumber: info.workplacePhoneNumber,
+        address: {
+          basic,
+          detail: detailParts.join(',').trim(),
+        },
+        spaceImage: { url: info.imageUrl },
+        rooms: roomList,
+      }));
+    }
+  }, [info, roomInfo]);
+
+  console.log(spaceFormData);
+
+  // 공간 등록에서 값 변경
+  const onChange = useCallback((data: Partial<Space>) => {
+    setSpaceFormData((prev) => ({ ...prev, ...data }));
+  }, []);
+
+  const [selectedRoomId, setSelectedRoomId] = useState('');
+
+  const addRoom = () => {
+    const newRoomId = uuidv4();
+    setSpaceFormData((prev) => ({
+      ...prev,
+      rooms: [
+        ...prev.rooms,
+        {
+          id: newRoomId,
+          roomName: '',
+          description: '',
+          price: '',
+          people: 0,
+          roomImages: [],
+        },
+      ],
+    }));
+
+    setSelectedRoomId(newRoomId);
+  };
+
+  // 룸 등록에서 값 변경
+  const updateRoomData = useCallback(
+    (data: Partial<Room>) => {
+      setSpaceFormData((prev) => {
+        const updatedRooms = prev.rooms.map((room) =>
+          room.id === selectedRoomId ? { ...room, ...data } : room,
+        );
+        return { ...prev, rooms: updatedRooms };
+      });
+    },
+    [selectedRoomId],
+  );
+
+  return (
+    <MainLayout>
+      {selectedRoomId ? (
+        <HeaderOnlyTitle title='룸 등록 및 수정' />
+      ) : (
+        <HeaderOnlyTitle title='공간 등록 수정' />
+      )}
+      <hr className='fixed top-[93px] mx-[22.5px] h-0.5 w-custom border-0 bg-black' />
+      {selectedRoomId ? (
+        <RoomForm
+          room={spaceFormData.rooms.find(({ id }) => id === selectedRoomId)!}
+          updateRoomData={updateRoomData}
+          completeAdd={setSelectedRoomId}
+          modify={modify}
+        />
+      ) : (
+        <SpaceForm
+          spaceFormData={spaceFormData}
+          changeFormdata={onChange}
+          addRoom={addRoom}
+          clickRoom={setSelectedRoomId}
+          modify={modify}
+        />
+      )}
+    </MainLayout>
+  );
+};
+
+export default ModifySpace;

--- a/src/pages/RegisterSpace/components/SpaceForm.tsx
+++ b/src/pages/RegisterSpace/components/SpaceForm.tsx
@@ -18,6 +18,7 @@ interface SpaceFormProps {
   changeFormdata: (data: Partial<Space>) => void;
   addRoom: () => void;
   clickRoom: (id: string) => void;
+  modify: boolean;
 }
 
 const SpaceForm = ({
@@ -25,6 +26,7 @@ const SpaceForm = ({
   changeFormdata,
   addRoom,
   clickRoom,
+  modify,
 }: SpaceFormProps) => {
   const handleChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -349,7 +351,7 @@ const SpaceForm = ({
           type='submit'
           className='btn-primary mt-[40px] text-[16px]'
         >
-          공간 등록 완료
+          {modify ? '수정 완료' : '공간 등록 완료'}
         </button>
       </form>
     </div>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -30,6 +30,7 @@ import ChatPage from '@pages/ChatPage';
 import PaymentFailPage from '@pages/PaymentPage/PaymentFailPage';
 import PaymentLoadingPage from '@pages/PaymentPage/PaymentLoadingPage';
 import OAuth from '@pages/UserLogin/components/OAuth';
+import ModifySpace from '@pages/ModifySpace';
 
 const router = createBrowserRouter([
   {
@@ -63,6 +64,10 @@ const router = createBrowserRouter([
   {
     path: '/register-Space',
     element: <RegisterSpace />,
+  },
+  {
+    path: '/modify-Space/:workplaceId',
+    element: <ModifySpace />,
   },
   {
     path: '/detail/:workplaceId',

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -14,7 +14,7 @@ export type Space = {
   closedTime: string;
   phoneNumber: string;
   address: { basic: string; detail: string };
-  spaceImage: File | null;
+  spaceImage: File | { url: string } | null;
   rooms: Room[];
 };
 
@@ -107,6 +107,7 @@ export interface Review extends PostReviewRequestBody {
 
 // 스터디룸 정보
 export interface StudyRoomData {
+  id: number;
   title: string;
   description: string;
   imageUrl: string;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,4 +11,15 @@ const removeAuthToken = () => {
   localStorage.removeItem('accessToken');
 };
 
-export { setAuthToken, getAuthToken, removeAuthToken };
+// role 저장
+
+const setRole = (role: string) => {
+  localStorage.setItem('role', role);
+};
+
+const getRole = () => {
+  const role = localStorage.getItem('role');
+  return role;
+};
+
+export { setAuthToken, getAuthToken, removeAuthToken, setRole, getRole };


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 수정 페이지 1차 및 토큰/role 저장

## 📝 요구 사항과 구현 내용
- 수정 페이지 라우터 연결
- role 저장 및 조회 함수 생성
- 토큰 바디가 아니라 헤더에서 가져오는 걸로 수정

## 💬 PR 포인트 & 궁금한 점
- 수정 페이지 내용 불러오는 거 하는 도중에 회원가입 쪽 수정하느라 섞였습니당..ㅋㅋㅋㅋ
