### PR TITLE
✨ Feat : 회원 정보 조회 페이지 구현 및 정보 수정 기능 완료

### DIFF
--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -14,11 +14,8 @@ export const getUserAlarm = async (): Promise<Alarm> => {
 };
 
 // 회원 정보 수정
-export const putEditMemberInformation = async (
-  data: Member,
-): Promise<Member> => {
-  const response = await authInstance.put('/api/v1/member', data);
-  return response.data;
+export const putEditMemberInformation = async (data: Member): Promise<void> => {
+  await authInstance.put('/api/v1/member', data);
 };
 
 // 사용자 탈퇴

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -6,16 +6,18 @@ const HostInfo = () => {
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
-    <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
-      <div className='text-[32px] font-bold leading-none text-white'>
-        {data?.businessName || (
-          <p className='text-2xl'>닉네임을 불러올 수 없습니다.</p>
-        )}
-      </div>
-      <div className='pt-0 text-[14px] text-white'>
-        {data?.businessEmail || <p>이메일을 불러올 수 없습니다.</p>}
-      </div>
-    </div>
+    <>
+      {data && (
+        <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
+          <div className='text-[32px] font-bold leading-none text-white'>
+            {data.businessName}
+          </div>
+          <div className='pt-0 text-[14px] text-white'>
+            {data.businessEmail}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
@@ -1,10 +1,16 @@
 import DeleteAccountButton from '@components/DeleteAccountButton';
+import { useLocation } from 'react-router-dom';
+import { Member } from '@typings/types';
 import UserEditForm from './UserEditForm';
 
 const UserEditContainer = () => {
+  const location = useLocation();
+  const user: Member = { ...location.state };
+  console.log(user);
+
   return (
     <div className='relative mt-14 flex w-[375px] flex-col'>
-      <UserEditForm />
+      <UserEditForm user={user} />
       <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
         <DeleteAccountButton />
       </div>

--- a/src/pages/UserInfoEditPage/components/UserEditForm.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditForm.tsx
@@ -1,51 +1,48 @@
 import CommonInput from '@components/CommonInput';
-import { ERROR_MESSAGE } from '@constants/constants';
-import { insertBirthHyphen } from '@utils/autoHyphen';
+import { ERROR_MESSAGE, PLACEHOLDER } from '@constants/constants';
+import { Member } from '@typings/types';
+import { insertBirthHyphen, insertPhoneNumberHyphen } from '@utils/autoHyphen';
 import {
   isValidBirth,
   isValidEmail,
   isValidNickname,
+  isValidUserPhoneNumber,
 } from '@utils/validationCheckRegex';
 import { ChangeEvent, FormEvent, useState } from 'react';
-
-interface EditData {
-  nickname: string;
-  email: string;
-  birth: string;
-}
+import usePutEditUserData from '../hooks/usePutEditUserData';
 
 interface EditErrorMessage {
   nicknameError?: string;
   emailError?: string;
   birthError?: string;
+  phoneNumberError?: string;
+  sexError?: string;
 }
 
-const user = {
-  nickname: 'HYUN',
-  email: 'hyun@gmail.com',
-  phone: '010-1111-2222',
-  birth: '2002-12-22',
-};
-
-const UserEditForm = () => {
-  const [newInformation, setNewInformation] = useState<EditData>({
-    nickname: user.nickname,
+const UserEditForm = ({ user }: { user: Member }) => {
+  const [newInformation, setNewInformation] = useState<Member>({
+    nickName: user.nickName,
     email: user.email,
-    birth: user.birth,
+    birthDay: user.birthDay,
+    sex: user.sex,
+    phoneNumber: user.phoneNumber,
   });
   const [errorMessage, setErrorMessage] = useState<EditErrorMessage>({});
+  const { mutate: editUser } = usePutEditUserData();
 
   const handleGetNewValue = (e: ChangeEvent<HTMLInputElement>): void => {
     const { name, value: originValue } = e.target;
     let value = originValue;
 
-    if (name === 'birth') {
+    if (name === 'birthDay') {
       value = insertBirthHyphen(value) || '';
     }
-
     // 닉네임이면 글자수 체크
-    if (name === 'nickname' && value.length > 10) {
+    if (name === 'nickName' && value.length > 10) {
       value = value.substring(0, 10);
+    }
+    if (name === 'phoneNumber') {
+      value = insertPhoneNumberHyphen(value) || '';
     }
 
     setNewInformation({ ...newInformation, [name]: value });
@@ -56,16 +53,24 @@ const UserEditForm = () => {
       nicknameError: '',
       emailError: '',
       birthError: '',
+      phoneNumberError: '',
+      sexError: '',
     };
 
-    if (!isValidNickname(newInformation.nickname)) {
+    if (!isValidNickname(newInformation.nickName)) {
       errors.nicknameError = ERROR_MESSAGE.nickname;
     }
     if (!isValidEmail(newInformation.email)) {
       errors.emailError = ERROR_MESSAGE.email;
     }
-    if (!isValidBirth(newInformation.birth)) {
+    if (!isValidBirth(newInformation.birthDay)) {
       errors.birthError = ERROR_MESSAGE.birth;
+    }
+    if (!isValidUserPhoneNumber(newInformation.phoneNumber)) {
+      errors.phoneNumberError = ERROR_MESSAGE.phonNumber;
+    }
+    if (newInformation.sex === '') {
+      errors.sexError = ERROR_MESSAGE.gender;
     }
 
     return errors;
@@ -77,19 +82,21 @@ const UserEditForm = () => {
 
     const errors = isValid();
     const newData = {
-      nickname: newInformation.nickname,
+      nickName: newInformation.nickName,
       email: newInformation.email,
-      birth: newInformation.birth,
+      birthDay: newInformation.birthDay,
+      sex: newInformation.sex,
+      phoneNumber: newInformation.phoneNumber,
     };
 
     if (
       isValidEmail(newInformation.email) &&
-      isValidNickname(newInformation.nickname) &&
-      isValidBirth(newInformation.birth)
+      isValidNickname(newInformation.nickName) &&
+      isValidBirth(newInformation.birthDay) &&
+      isValidUserPhoneNumber(newInformation.phoneNumber)
     ) {
-      console.log(
-        `정보 수정 완료: ${newData.nickname}, ${newData.birth}, ${newData.email}`,
-      );
+      editUser(newData);
+      console.log(`정보 수정 완료: ${newInformation}`);
     } else {
       setErrorMessage(errors);
     }
@@ -100,13 +107,55 @@ const UserEditForm = () => {
       className='mx-auto flex w-custom flex-col justify-center gap-10'
       onSubmit={onSubmitHandler}
     >
+      <div className='flex flex-col gap-3'>
+        <p className='mr-[34px] text-[14px] font-normal'>성별</p>
+        <div className='flex'>
+          <div className='flex items-center'>
+            <input
+              type='radio'
+              name='sex'
+              value='MALE'
+              className='mr-[6px]'
+              onChange={handleGetNewValue}
+              checked={newInformation.sex === 'MALE'}
+            />
+            <label
+              htmlFor='MALE'
+              className='mr-[20px] text-[14px]'
+            >
+              남자
+            </label>
+          </div>
+          <div className='flex items-center'>
+            <input
+              type='radio'
+              name='sex'
+              value='FEMALE'
+              className='w-[14px mr-[6px] h-[14px]'
+              onChange={handleGetNewValue}
+              checked={newInformation.sex === 'FEMALE'}
+            />
+            <label
+              htmlFor='FEMALE'
+              className='text-[14px]'
+            >
+              여자
+            </label>
+          </div>
+        </div>
+        {errorMessage.sexError && (
+          <p className='text-[12px] font-medium text-[#F83A3A]'>
+            {errorMessage.sexError}
+          </p>
+        )}
+      </div>
       <div className='flex flex-col gap-6'>
         <div className='flex flex-col gap-1'>
           <CommonInput
             label='닉네임'
-            name='nickname'
-            placeholder='새로운 닉네임을 입력하세요.'
-            value={newInformation.nickname}
+            name='nickName'
+            placeholder={PLACEHOLDER.nickname}
+            value={newInformation.nickName}
             onChangeFunction={handleGetNewValue}
             maxLength={10}
           />
@@ -120,7 +169,7 @@ const UserEditForm = () => {
           <CommonInput
             label='이메일'
             name='email'
-            placeholder='새로운 이메일을 입력하세요.'
+            placeholder={PLACEHOLDER.email}
             value={newInformation.email}
             onChangeFunction={handleGetNewValue}
           />
@@ -132,10 +181,24 @@ const UserEditForm = () => {
         </div>
         <div className='flex flex-col gap-1'>
           <CommonInput
+            label='전화번호'
+            name='phoneNumber'
+            placeholder={PLACEHOLDER.phonNumber}
+            value={newInformation.phoneNumber}
+            onChangeFunction={handleGetNewValue}
+          />
+          {errorMessage.phoneNumberError && (
+            <p className='text-[12px] font-medium text-[#F83A3A]'>
+              {errorMessage.phoneNumberError}
+            </p>
+          )}
+        </div>
+        <div className='flex flex-col gap-1'>
+          <CommonInput
             label='생년월일'
-            name='birth'
+            name='birthDay'
             placeholder='YYYY-MM-DD'
-            value={newInformation.birth}
+            value={newInformation.birthDay}
             onChangeFunction={handleGetNewValue}
           />
           {errorMessage.birthError && (

--- a/src/pages/UserInfoEditPage/components/UserEditForm.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditForm.tsx
@@ -96,7 +96,6 @@ const UserEditForm = ({ user }: { user: Member }) => {
       isValidUserPhoneNumber(newInformation.phoneNumber)
     ) {
       editUser(newData);
-      console.log(`정보 수정 완료: ${newInformation}`);
     } else {
       setErrorMessage(errors);
     }

--- a/src/pages/UserInfoEditPage/hooks/usePutEditUserData.ts
+++ b/src/pages/UserInfoEditPage/hooks/usePutEditUserData.ts
@@ -1,0 +1,22 @@
+import { putEditMemberInformation } from '@apis/member';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Member } from '@typings/types';
+import { useNavigate } from 'react-router-dom';
+
+const usePutEditUserData = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const editUser = useMutation({
+    mutationFn: (user: Member) => putEditMemberInformation(user),
+    onSuccess: () => {
+      console.log('정보 수정 완료');
+      queryClient.invalidateQueries({ queryKey: ['member'] });
+      navigate('/user-info');
+    },
+  });
+
+  return editUser;
+};
+
+export default usePutEditUserData;

--- a/src/pages/UserInfoEditPage/hooks/usePutEditUserData.ts
+++ b/src/pages/UserInfoEditPage/hooks/usePutEditUserData.ts
@@ -10,7 +10,6 @@ const usePutEditUserData = () => {
   const editUser = useMutation({
     mutationFn: (user: Member) => putEditMemberInformation(user),
     onSuccess: () => {
-      console.log('정보 수정 완료');
       queryClient.invalidateQueries({ queryKey: ['member'] });
       navigate('/user-info');
     },

--- a/src/pages/UserInfoPage/components/UserInfoBox.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoBox.tsx
@@ -1,27 +1,64 @@
 import LabelWithInput from '@components/LabelWithInput';
-import useGetUserData from '@pages/UserMypage/hooks/useGetUserData';
+import { Member } from '@typings/types';
 import { getDateFunction } from '@utils/formatTime';
 
-const UserInfoBox = () => {
-  const { user } = useGetUserData();
+const UserInfoBox = ({ user }: { user: Member }) => {
+  const { nickName, email, phoneNumber, birthDay, sex } = user;
 
   return (
     <div className='flex flex-col gap-10'>
+      <div className='flex flex-col gap-3'>
+        <p className='mr-[34px] text-[14px] font-normal'>성별</p>
+        <div className='flex'>
+          <div className='flex items-center'>
+            <input
+              type='radio'
+              name='gender'
+              value='MALE'
+              className='mr-[6px]'
+              checked={sex === 'MALE'}
+              readOnly
+            />
+            <label
+              htmlFor='MALE'
+              className='mr-[20px] text-[14px]'
+            >
+              남자
+            </label>
+          </div>
+          <div className='flex items-center'>
+            <input
+              type='radio'
+              name='gender'
+              value='FEMALE'
+              className='w-[14px mr-[6px] h-[14px]'
+              checked={sex === 'FEMALE'}
+              readOnly
+            />
+            <label
+              htmlFor='FEMALE'
+              className='text-[14px]'
+            >
+              여자
+            </label>
+          </div>
+        </div>
+      </div>
       <LabelWithInput
         label='닉네임'
-        value={user.nickName}
+        value={nickName}
       />
       <LabelWithInput
         label='이메일'
-        value={user.email}
+        value={email}
       />
       <LabelWithInput
         label='전화번호'
-        value={user.phoneNumber}
+        value={phoneNumber}
       />
       <LabelWithInput
         label='생년월일'
-        value={getDateFunction(user.birthDay)}
+        value={getDateFunction(birthDay)}
       />
     </div>
   );

--- a/src/pages/UserInfoPage/components/UserInfoBox.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoBox.tsx
@@ -1,26 +1,27 @@
 import LabelWithInput from '@components/LabelWithInput';
-
-const user = {
-  name: 'HYUN',
-  email: 'hyun@gmail.com',
-  phone: '010-1111-2222',
-  birth: '2002.12.22',
-};
+import useGetUserData from '@pages/UserMypage/hooks/useGetUserData';
+import { getDateFunction } from '@utils/formatTime';
 
 const UserInfoBox = () => {
+  const { user } = useGetUserData();
+
   return (
     <div className='flex flex-col gap-10'>
       <LabelWithInput
         label='닉네임'
-        value={user.name}
+        value={user.nickName}
       />
       <LabelWithInput
         label='이메일'
         value={user.email}
       />
       <LabelWithInput
+        label='전화번호'
+        value={user.phoneNumber}
+      />
+      <LabelWithInput
         label='생년월일'
-        value={user.birth}
+        value={getDateFunction(user.birthDay)}
       />
     </div>
   );

--- a/src/pages/UserInfoPage/components/UserInfoContainer.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoContainer.tsx
@@ -9,9 +9,7 @@ const UserInfoContainer = () => {
 
   const handleMoveEditPage = () => {
     navigate('/user-info-edit', {
-      state: {
-        userData: user,
-      },
+      state: user,
     });
   };
 

--- a/src/pages/UserInfoPage/components/UserInfoContainer.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoContainer.tsx
@@ -18,7 +18,7 @@ const UserInfoContainer = () => {
           className='flex h-[30px] items-center gap-1 self-end text-subfont active:text-primary'
           onClick={handleMoveEditPage}
         >
-          정보 수정하기
+          수정하기
           <MdArrowForwardIos />
         </button>
       </div>

--- a/src/pages/UserInfoPage/components/UserInfoContainer.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoContainer.tsx
@@ -1,18 +1,24 @@
 import { useNavigate } from 'react-router-dom';
 import { MdArrowForwardIos } from 'react-icons/md';
+import useGetUserData from '@pages/UserMypage/hooks/useGetUserData';
 import UserInfoBox from './UserInfoBox';
 
 const UserInfoContainer = () => {
   const navigate = useNavigate();
+  const { user } = useGetUserData();
 
   const handleMoveEditPage = () => {
-    navigate('/user-info-edit');
+    navigate('/user-info-edit', {
+      state: {
+        userData: user,
+      },
+    });
   };
 
   return (
     <div className='mt-14 flex w-[375px] flex-col justify-center'>
       <div className='mx-auto flex w-custom flex-col justify-center gap-10'>
-        <UserInfoBox />
+        <UserInfoBox user={user} />
         <button
           type='button'
           className='flex h-[30px] items-center gap-1 self-end text-subfont active:text-primary'

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -1,19 +1,19 @@
 import useGetUserData from '../hooks/useGetUserData';
 
 const UserInfo = () => {
-  const { data } = useGetUserData();
+  const { user } = useGetUserData();
   // const navigate = useNavigate();
 
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
     <>
-      {data && (
+      {user && (
         <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
           <div className='text-[32px] font-semibold leading-none text-white'>
-            {data.nickName}
+            {user.nickName}
           </div>
-          <div className='pt-0 text-[14px] text-white'>{data.email}</div>
+          <div className='pt-0 text-[14px] text-white'>{user.email}</div>
         </div>
       )}
     </>

--- a/src/pages/UserMypage/components/UserInfo.tsx
+++ b/src/pages/UserMypage/components/UserInfo.tsx
@@ -7,16 +7,16 @@ const UserInfo = () => {
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
-    <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
-      <div className='text-[32px] font-semibold leading-none text-white'>
-        {data?.nickName || (
-          <p className='text-2xl'>닉네임을 불러올 수 없습니다.</p>
-        )}
-      </div>
-      <div className='pt-0 text-[14px] text-white'>
-        {data?.email || <p>이메일을 불러올 수 없습니다.</p>}
-      </div>
-    </div>
+    <>
+      {data && (
+        <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
+          <div className='text-[32px] font-semibold leading-none text-white'>
+            {data.nickName}
+          </div>
+          <div className='pt-0 text-[14px] text-white'>{data.email}</div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/pages/UserMypage/hooks/useGetUserData.ts
+++ b/src/pages/UserMypage/hooks/useGetUserData.ts
@@ -1,12 +1,13 @@
 import { getUserData } from '@apis/member';
 import { useQuery } from '@tanstack/react-query';
+import { Member } from '@typings/types';
 
 const useGetUserData = () => {
   const { data } = useQuery({
     queryKey: ['member'],
     queryFn: () => getUserData(),
   });
-  return { data };
+  return { user: (data ?? []) as Member };
 };
 
 export default useGetUserData;

--- a/src/pages/WriteReviewPage/components/WriteReview.tsx
+++ b/src/pages/WriteReviewPage/components/WriteReview.tsx
@@ -18,7 +18,7 @@ const WriteReview = ({
     reviewRating: 0,
   });
 
-  const { mutate: writeReview } = usePostReview(postData);
+  const { mutate: writeReview } = usePostReview();
 
   // 별 표시
   const handleStarClick = () => {
@@ -54,7 +54,7 @@ const WriteReview = ({
   const submitHandler = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log(postData);
-    writeReview();
+    writeReview(postData);
   };
 
   return (

--- a/src/pages/WriteReviewPage/hooks/usePostReview.ts
+++ b/src/pages/WriteReviewPage/hooks/usePostReview.ts
@@ -3,13 +3,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PostReviewRequestBody } from '@typings/types';
 import { useNavigate } from 'react-router-dom';
 
-const usePostReview = (data: PostReviewRequestBody) => {
+const usePostReview = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   const writeReview = useMutation({
-    mutationFn: () => postReview(data),
-    onSuccess: () => {
+    mutationFn: (data: PostReviewRequestBody) => postReview(data),
+    onSuccess: (data) => {
       console.log(data, '리뷰 작성 성공');
       queryClient.invalidateQueries({ queryKey: ['myReview'] });
       navigate('/review-list');

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -57,7 +57,7 @@ export interface BusinessAlarm {}
 export interface Member {
   nickName: string;
   phoneNumber: string;
-  birthDay: Date;
+  birthDay: string;
   sex: string;
   email: string;
   createdAt?: string;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사용자 정보 조회 및 수정 기능 완료

## 📝 요구 사항과 구현 내용
- 사용자 정보 조회 및 수정
  - 사용자 정보 조회에 성별, 전화번호 추가
  - '정보 수정하기' 버튼 -> '수정하기' 로 변경
- 사용자 birthDay 타입을 string으로 수정
- 사용자 정보 수정 api에서 반환값 삭제 및 반환 타입 변경
- 리뷰 작성 페이지에서 뮤테이션 함수 수정

## 💬 PR 포인트 & 궁금한 점
- 사업자, 사용자 정보 조회 undifiend 처리를 변경했습니다. 
  원래대로 아래 코드처럼 사용하면 렌더링이 되기 전에 닉네임을 불러올 수 없다는 문구가 먼저 떠버려서 다시 변경했습니다..!    
  ```
  {data?.businessName || (
       <p className='text-2xl'>닉네임을 불러올 수 없습니다.</p>
  )}
  ```

## 🔗 연관된 이슈
- close #44