### PR TITLE
✨ Feat : 사업자 정보 수정, 조회 페이지 및 회원 탈퇴 버튼 api 연결

### DIFF
--- a/src/apis/business.ts
+++ b/src/apis/business.ts
@@ -16,9 +16,8 @@ export const getBusinessAlarm = async (): Promise<BusinessAlarm> => {
 // 사업자 정보 수정
 export const putEditBusinessInformation = async (
   data: Business,
-): Promise<Business> => {
-  const response = await authInstance.put('/api/v1/business', data);
-  return response.data;
+): Promise<void> => {
+  await authInstance.put('/api/v1/business', data);
 };
 
 // 사업자 탈퇴

--- a/src/components/DeleteAccountButton.tsx
+++ b/src/components/DeleteAccountButton.tsx
@@ -1,8 +1,13 @@
-const DeleteAccountButton = () => {
+interface DeleteAccountProp {
+  onClickButton: () => void;
+}
+
+const DeleteAccountButton = ({ onClickButton }: DeleteAccountProp) => {
   return (
     <button
       type='button'
       className='h-[23px] w-[100%] text-[12px] text-subfont underline active:text-black'
+      onClick={onClickButton}
     >
       탈퇴하시겠습니까?
     </button>

--- a/src/pages/BusinessSignUp/components/BusinessSignUpForm.tsx
+++ b/src/pages/BusinessSignUp/components/BusinessSignUpForm.tsx
@@ -24,7 +24,7 @@ const BusinessSignUpForm = () => {
   // input 값 반영
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.name === 'nickname' && e.target.value.length > 8) {
-      e.target.value = e.target.value.substring(0, 8);
+      e.target.value = e.target.value.substring(0, 10);
     }
     setHostFormData({
       ...hostFormData,

--- a/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
@@ -1,10 +1,14 @@
 import DeleteAccountButton from '@components/DeleteAccountButton';
 import { useState } from 'react';
 import Modal from '@components/Modal';
+import { useLocation } from 'react-router-dom';
+import { Business } from '@typings/types';
 import HostEditForm from './HostEditForm';
 import useDeleteBusiness from '../hooks/useDeleteBusiness';
 
 const HostEditContainer = () => {
+  const location = useLocation();
+  const business: Business = { ...location.state };
   const { mutate } = useDeleteBusiness();
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -16,7 +20,7 @@ const HostEditContainer = () => {
   return (
     <>
       <div className='relative mt-14 flex w-[375px] flex-col'>
-        <HostEditForm />
+        <HostEditForm business={business} />
         <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>

--- a/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
@@ -19,9 +19,9 @@ const HostEditContainer = () => {
 
   return (
     <>
-      <div className='relative mt-14 flex w-[375px] flex-col'>
+      <div className='relative mt-10 flex w-[375px] flex-col'>
         <HostEditForm business={business} />
-        <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
+        <div className='absolute bottom-[-300px] left-[50%] translate-x-[-50%]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>
       </div>

--- a/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
@@ -19,9 +19,9 @@ const HostEditContainer = () => {
 
   return (
     <>
-      <div className='relative mt-10 flex w-[375px] flex-col'>
+      <div className='relative mt-10 flex w-[375px] flex-col items-center'>
         <HostEditForm business={business} />
-        <div className='absolute bottom-[-300px] left-[50%] translate-x-[-50%]'>
+        <div className='mb-4 mt-[275px]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>
       </div>

--- a/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditContainer.tsx
@@ -1,14 +1,34 @@
 import DeleteAccountButton from '@components/DeleteAccountButton';
+import { useState } from 'react';
+import Modal from '@components/Modal';
 import HostEditForm from './HostEditForm';
+import useDeleteBusiness from '../hooks/useDeleteBusiness';
 
 const HostEditContainer = () => {
+  const { mutate } = useDeleteBusiness();
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleDeleteAccountClick = () => {
+    mutate();
+  };
+
   return (
-    <div className='relative mt-14 flex w-[375px] flex-col'>
-      <HostEditForm />
-      <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
-        <DeleteAccountButton />
+    <>
+      <div className='relative mt-14 flex w-[375px] flex-col'>
+        <HostEditForm />
+        <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
+          <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
+        </div>
       </div>
-    </div>
+      {modalOpen && (
+        <Modal
+          message='정말 탈퇴하시겠습니까?'
+          onCancelButtonClick={() => setModalOpen(false)}
+          onConfirmButtonClick={handleDeleteAccountClick}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/HostInfoEditPage/components/HostEditForm.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditForm.tsx
@@ -1,5 +1,6 @@
 import CommonInput from '@components/CommonInput';
-import { ERROR_MESSAGE } from '@constants/constants';
+import { ERROR_MESSAGE, PLACEHOLDER } from '@constants/constants';
+import { Business } from '@typings/types';
 import { insertBusinessNumberHyphen } from '@utils/autoHyphen';
 import {
   isValidBusinessNumber,
@@ -7,12 +8,7 @@ import {
   isValidNickname,
 } from '@utils/validationCheckRegex';
 import { ChangeEvent, FormEvent, useState } from 'react';
-
-interface EditData {
-  nickname: string;
-  email: string;
-  businessNumber: string;
-}
+import usePutEditBusinessData from '../hooks/usePutEditBusinessData';
 
 interface EditErrorMessage {
   nicknameError?: string;
@@ -20,30 +16,24 @@ interface EditErrorMessage {
   businessNumberError?: string;
 }
 
-const host = {
-  nickname: 'HOST',
-  email: 'host@gmail.com',
-  businessNumber: '000-00-00000',
-};
-
-const HostEditForm = () => {
-  const [newInformation, setNewInformation] = useState<EditData>({
-    nickname: host.nickname,
-    email: host.email,
-    businessNumber: host.businessNumber,
+const HostEditForm = ({ business }: { business: Business }) => {
+  const [newInformation, setNewInformation] = useState<Business>({
+    businessName: business.businessName,
+    businessEmail: business.businessEmail,
+    businessNum: business.businessNum,
   });
   const [errorMessage, setErrorMessage] = useState<EditErrorMessage>({});
+  const { mutate: editBusiness } = usePutEditBusinessData();
 
   const handleGetNewValue = (e: ChangeEvent<HTMLInputElement>): void => {
     const { name, value: originValue } = e.target;
     let value = originValue;
 
     // 닉네임이면 글자수 체크
-    if (name === 'nickname' && value.length > 10) {
+    if (name === 'businessName' && value.length > 10) {
       value = value.substring(0, 10);
     }
-
-    if (name === 'businessNumber') {
+    if (name === 'businessNum') {
       value = insertBusinessNumberHyphen(value) || '';
     }
 
@@ -57,13 +47,13 @@ const HostEditForm = () => {
       businessNumberError: '',
     };
 
-    if (!isValidNickname(newInformation.nickname)) {
+    if (!isValidNickname(newInformation.businessName)) {
       errors.nicknameError = ERROR_MESSAGE.nickname;
     }
-    if (!isValidEmail(newInformation.email)) {
+    if (!isValidEmail(newInformation.businessEmail)) {
       errors.emailError = ERROR_MESSAGE.email;
     }
-    if (!isValidBusinessNumber(newInformation.businessNumber)) {
+    if (!isValidBusinessNumber(newInformation.businessNum)) {
       errors.businessNumberError = ERROR_MESSAGE.businessNumber;
     }
 
@@ -76,19 +66,17 @@ const HostEditForm = () => {
 
     const errors = isValid();
     const newData = {
-      nickname: newInformation.nickname,
-      email: newInformation.email,
-      businessNumber: newInformation.businessNumber,
+      businessName: newInformation.businessName,
+      businessEmail: newInformation.businessEmail,
+      businessNum: newInformation.businessNum,
     };
 
     if (
-      isValidEmail(newInformation.email) &&
-      isValidNickname(newInformation.nickname) &&
-      isValidBusinessNumber(newInformation.businessNumber)
+      isValidEmail(newInformation.businessEmail) &&
+      isValidNickname(newInformation.businessName) &&
+      isValidBusinessNumber(newInformation.businessNum)
     ) {
-      console.log(
-        `정보 수정 완료: ${newData.nickname}, ${newData.businessNumber}, ${newData.email}`,
-      );
+      editBusiness(newData);
     } else {
       setErrorMessage(errors);
     }
@@ -103,9 +91,9 @@ const HostEditForm = () => {
         <div className='flex flex-col gap-1'>
           <CommonInput
             label='닉네임'
-            name='nickname'
+            name='businessName'
             placeholder='새로운 닉네임을 입력하세요.'
-            value={newInformation.nickname}
+            value={newInformation.businessName}
             onChangeFunction={handleGetNewValue}
             maxLength={10}
           />
@@ -118,9 +106,9 @@ const HostEditForm = () => {
         <div className='flex flex-col gap-1'>
           <CommonInput
             label='이메일'
-            name='email'
+            name='businessEmail'
             placeholder='새로운 이메일을 입력하세요.'
-            value={newInformation.email}
+            value={newInformation.businessEmail}
             onChangeFunction={handleGetNewValue}
           />
           {errorMessage.emailError && (
@@ -132,9 +120,9 @@ const HostEditForm = () => {
         <div className='flex flex-col gap-1'>
           <CommonInput
             label='사업자 등록번호'
-            name='businessNumber'
-            placeholder='000-00-00000'
-            value={newInformation.businessNumber}
+            name='businessNum'
+            placeholder={PLACEHOLDER.businessNumber}
+            value={newInformation.businessNum}
             onChangeFunction={handleGetNewValue}
           />
           {errorMessage.businessNumberError && (

--- a/src/pages/HostInfoEditPage/components/HostEditForm.tsx
+++ b/src/pages/HostInfoEditPage/components/HostEditForm.tsx
@@ -92,7 +92,7 @@ const HostEditForm = ({ business }: { business: Business }) => {
           <CommonInput
             label='닉네임'
             name='businessName'
-            placeholder='새로운 닉네임을 입력하세요.'
+            placeholder={PLACEHOLDER.nickname}
             value={newInformation.businessName}
             onChangeFunction={handleGetNewValue}
             maxLength={10}
@@ -107,7 +107,7 @@ const HostEditForm = ({ business }: { business: Business }) => {
           <CommonInput
             label='이메일'
             name='businessEmail'
-            placeholder='새로운 이메일을 입력하세요.'
+            placeholder={PLACEHOLDER.email}
             value={newInformation.businessEmail}
             onChangeFunction={handleGetNewValue}
           />

--- a/src/pages/HostInfoEditPage/hooks/useDeleteBusiness.ts
+++ b/src/pages/HostInfoEditPage/hooks/useDeleteBusiness.ts
@@ -1,0 +1,18 @@
+import { deleteBusiness } from '@apis/business';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+const useDeleteBusiness = () => {
+  const navigate = useNavigate();
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteBusiness(),
+    onSuccess: () => {
+      navigate('/');
+    },
+  });
+
+  return deleteMutation;
+};
+
+export default useDeleteBusiness;

--- a/src/pages/HostInfoEditPage/hooks/usePutEditBusinessData.ts
+++ b/src/pages/HostInfoEditPage/hooks/usePutEditBusinessData.ts
@@ -1,0 +1,21 @@
+import { putEditBusinessInformation } from '@apis/business';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Business } from '@typings/types';
+import { useNavigate } from 'react-router-dom';
+
+const usePutEditBusinessData = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const editBusiness = useMutation({
+    mutationFn: (business: Business) => putEditBusinessInformation(business),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['business'] });
+      navigate('/host-info');
+    },
+  });
+
+  return editBusiness;
+};
+
+export default usePutEditBusinessData;

--- a/src/pages/HostInfoPage/components/HostInfoBox.tsx
+++ b/src/pages/HostInfoPage/components/HostInfoBox.tsx
@@ -1,25 +1,20 @@
 import LabelWithInput from '@components/LabelWithInput';
+import { Business } from '@typings/types';
 
-const host = {
-  name: 'HOST',
-  email: 'host@gmail.com',
-  businessNumber: '000-00-0000',
-};
-
-const HostInfoBox = () => {
+const HostInfoBox = ({ business }: { business: Business }) => {
   return (
     <div className='flex flex-col gap-10'>
       <LabelWithInput
         label='닉네임'
-        value={host.name}
+        value={business.businessName}
       />
       <LabelWithInput
         label='이메일'
-        value={host.email}
+        value={business.businessEmail}
       />
       <LabelWithInput
         label='사업자 등록번호'
-        value={host.businessNumber}
+        value={business.businessNum}
       />
     </div>
   );

--- a/src/pages/HostInfoPage/components/HostInfoContainer.tsx
+++ b/src/pages/HostInfoPage/components/HostInfoContainer.tsx
@@ -12,9 +12,9 @@ const HostInfoContainer = () => {
   };
 
   return (
-    <div className='mt-14 flex w-[375px] flex-col justify-center'>
+    <div className='mt-10 flex w-[375px] flex-col justify-center'>
       <div className='mx-auto flex w-custom flex-col justify-center gap-10'>
-        <HostInfoBox />
+        <HostInfoBox business={business} />
         <button
           type='button'
           className='flex h-[30px] items-center gap-1 self-end text-subfont active:text-primary'

--- a/src/pages/HostInfoPage/components/HostInfoContainer.tsx
+++ b/src/pages/HostInfoPage/components/HostInfoContainer.tsx
@@ -1,12 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import { MdArrowForwardIos } from 'react-icons/md';
+import useGetBusinessData from '@pages/HostMypage/hooks/useGetBusinessData';
 import HostInfoBox from './HostInfoBox';
 
 const HostInfoContainer = () => {
   const navigate = useNavigate();
+  const { business } = useGetBusinessData();
 
   const handleMoveEditPage = () => {
-    navigate('/host-info-edit');
+    navigate('/host-info-edit', { state: business });
   };
 
   return (
@@ -18,7 +20,7 @@ const HostInfoContainer = () => {
           className='flex h-[30px] items-center gap-1 self-end text-subfont active:text-primary'
           onClick={handleMoveEditPage}
         >
-          정보 수정하기
+          수정하기
           <MdArrowForwardIos />
         </button>
       </div>

--- a/src/pages/HostMypage/components/HostInfo.tsx
+++ b/src/pages/HostMypage/components/HostInfo.tsx
@@ -1,19 +1,19 @@
 import useGetBusinessData from '../hooks/useGetBusinessData';
 
 const HostInfo = () => {
-  const { data } = useGetBusinessData();
+  const { business } = useGetBusinessData();
 
   // 마이페이지 진입 시 토큰 유무(로그인 상태) 확인할 것
 
   return (
     <>
-      {data && (
+      {business && (
         <div className='flex flex-col gap-1 self-start pl-[24px] pt-[30px]'>
           <div className='text-[32px] font-bold leading-none text-white'>
-            {data.businessName}
+            {business.businessName}
           </div>
           <div className='pt-0 text-[14px] text-white'>
-            {data.businessEmail}
+            {business.businessEmail}
           </div>
         </div>
       )}

--- a/src/pages/HostMypage/hooks/useGetBusinessData.ts
+++ b/src/pages/HostMypage/hooks/useGetBusinessData.ts
@@ -1,12 +1,13 @@
 import { getBusinessData } from '@apis/business';
 import { useQuery } from '@tanstack/react-query';
+import { Business } from '@typings/types';
 
 const useGetBusinessData = () => {
   const { data } = useQuery({
     queryKey: ['business'],
     queryFn: () => getBusinessData(),
   });
-  return { data };
+  return { business: (data ?? {}) as Business };
 };
 
 export default useGetBusinessData;

--- a/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
@@ -1,20 +1,39 @@
 import DeleteAccountButton from '@components/DeleteAccountButton';
 import { useLocation } from 'react-router-dom';
 import { Member } from '@typings/types';
+import { useState } from 'react';
+import Modal from '@components/Modal';
 import UserEditForm from './UserEditForm';
+import useDeleteMember from '../hooks/useDeleteMember';
 
 const UserEditContainer = () => {
   const location = useLocation();
   const user: Member = { ...location.state };
-  console.log(user);
+
+  const { mutate } = useDeleteMember();
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleDeleteAccountClick = () => {
+    mutate();
+  };
 
   return (
-    <div className='relative mt-14 flex w-[375px] flex-col'>
-      <UserEditForm user={user} />
-      <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
-        <DeleteAccountButton />
+    <>
+      <div className='relative mt-14 flex w-[375px] flex-col'>
+        <UserEditForm user={user} />
+        <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
+          <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
+        </div>
       </div>
-    </div>
+      {modalOpen && (
+        <Modal
+          message='정말 탈퇴하시겠습니까?'
+          onCancelButtonClick={() => setModalOpen(false)}
+          onConfirmButtonClick={handleDeleteAccountClick}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
@@ -22,7 +22,7 @@ const UserEditContainer = () => {
     <>
       <div className='relative mt-14 flex w-[375px] flex-col'>
         <UserEditForm user={user} />
-        <div className='absolute bottom-[-280px] left-[50%] translate-x-[-50%]'>
+        <div className='absolute bottom-[-200px] left-[50%] translate-x-[-50%]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>
       </div>

--- a/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
@@ -20,9 +20,9 @@ const UserEditContainer = () => {
 
   return (
     <>
-      <div className='relative mt-14 flex w-[375px] flex-col'>
+      <div className='relative mt-10 flex w-[375px] flex-col'>
         <UserEditForm user={user} />
-        <div className='absolute bottom-[-200px] left-[50%] translate-x-[-50%]'>
+        <div className='absolute bottom-[-110px] left-[50%] translate-x-[-50%]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>
       </div>

--- a/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditContainer.tsx
@@ -20,9 +20,9 @@ const UserEditContainer = () => {
 
   return (
     <>
-      <div className='relative mt-10 flex w-[375px] flex-col'>
+      <div className='relative mt-10 flex w-[375px] flex-col items-center'>
         <UserEditForm user={user} />
-        <div className='absolute bottom-[-110px] left-[50%] translate-x-[-50%]'>
+        <div className='mb-4 mt-[100px]'>
           <DeleteAccountButton onClickButton={() => setModalOpen(true)} />
         </div>
       </div>

--- a/src/pages/UserInfoEditPage/components/UserEditForm.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditForm.tsx
@@ -27,6 +27,7 @@ const UserEditForm = ({ user }: { user: Member }) => {
     sex: user.sex,
     phoneNumber: user.phoneNumber,
   });
+  console.log(newInformation);
   const [errorMessage, setErrorMessage] = useState<EditErrorMessage>({});
   const { mutate: editUser } = usePutEditUserData();
 
@@ -57,6 +58,9 @@ const UserEditForm = ({ user }: { user: Member }) => {
       sexError: '',
     };
 
+    if (newInformation.sex === '') {
+      errors.sexError = ERROR_MESSAGE.gender;
+    }
     if (!isValidNickname(newInformation.nickName)) {
       errors.nicknameError = ERROR_MESSAGE.nickname;
     }
@@ -68,9 +72,6 @@ const UserEditForm = ({ user }: { user: Member }) => {
     }
     if (!isValidUserPhoneNumber(newInformation.phoneNumber)) {
       errors.phoneNumberError = ERROR_MESSAGE.phonNumber;
-    }
-    if (newInformation.sex === '') {
-      errors.sexError = ERROR_MESSAGE.gender;
     }
 
     return errors;
@@ -90,6 +91,7 @@ const UserEditForm = ({ user }: { user: Member }) => {
     };
 
     if (
+      newInformation.sex !== '' &&
       isValidEmail(newInformation.email) &&
       isValidNickname(newInformation.nickName) &&
       isValidBirth(newInformation.birthDay) &&
@@ -106,49 +108,49 @@ const UserEditForm = ({ user }: { user: Member }) => {
       className='mx-auto flex w-custom flex-col justify-center gap-10'
       onSubmit={onSubmitHandler}
     >
-      <div className='flex flex-col gap-3'>
-        <p className='mr-[34px] text-[14px] font-normal'>성별</p>
-        <div className='flex'>
-          <div className='flex items-center'>
-            <input
-              type='radio'
-              name='sex'
-              value='MALE'
-              className='mr-[6px]'
-              onChange={handleGetNewValue}
-              checked={newInformation.sex === 'MALE'}
-            />
-            <label
-              htmlFor='MALE'
-              className='mr-[20px] text-[14px]'
-            >
-              남자
-            </label>
-          </div>
-          <div className='flex items-center'>
-            <input
-              type='radio'
-              name='sex'
-              value='FEMALE'
-              className='w-[14px mr-[6px] h-[14px]'
-              onChange={handleGetNewValue}
-              checked={newInformation.sex === 'FEMALE'}
-            />
-            <label
-              htmlFor='FEMALE'
-              className='text-[14px]'
-            >
-              여자
-            </label>
-          </div>
-        </div>
-        {errorMessage.sexError && (
-          <p className='text-[12px] font-medium text-[#F83A3A]'>
-            {errorMessage.sexError}
-          </p>
-        )}
-      </div>
       <div className='flex flex-col gap-6'>
+        <div className='flex flex-col gap-3'>
+          <p className='mr-[34px] text-[14px] font-normal'>성별</p>
+          <div className='flex'>
+            <div className='flex items-center'>
+              <input
+                type='radio'
+                name='sex'
+                value='MALE'
+                className='mr-[6px]'
+                onChange={handleGetNewValue}
+                checked={newInformation.sex === 'MALE'}
+              />
+              <label
+                htmlFor='MALE'
+                className='mr-[20px] text-[14px]'
+              >
+                남자
+              </label>
+            </div>
+            <div className='flex items-center'>
+              <input
+                type='radio'
+                name='sex'
+                value='FEMALE'
+                className='w-[14px mr-[6px] h-[14px]'
+                onChange={handleGetNewValue}
+                checked={newInformation.sex === 'FEMALE'}
+              />
+              <label
+                htmlFor='FEMALE'
+                className='text-[14px]'
+              >
+                여자
+              </label>
+            </div>
+          </div>
+          {errorMessage.sexError && (
+            <p className='text-[12px] font-medium text-[#F83A3A]'>
+              {errorMessage.sexError}
+            </p>
+          )}
+        </div>
         <div className='flex flex-col gap-1'>
           <CommonInput
             label='닉네임'

--- a/src/pages/UserInfoEditPage/components/UserEditForm.tsx
+++ b/src/pages/UserInfoEditPage/components/UserEditForm.tsx
@@ -27,7 +27,6 @@ const UserEditForm = ({ user }: { user: Member }) => {
     sex: user.sex,
     phoneNumber: user.phoneNumber,
   });
-  console.log(newInformation);
   const [errorMessage, setErrorMessage] = useState<EditErrorMessage>({});
   const { mutate: editUser } = usePutEditUserData();
 

--- a/src/pages/UserInfoEditPage/hooks/useDeleteMember.ts
+++ b/src/pages/UserInfoEditPage/hooks/useDeleteMember.ts
@@ -1,0 +1,18 @@
+import { deleteMember } from '@apis/member';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+const useDeleteMember = () => {
+  const navigate = useNavigate();
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteMember(),
+    onSuccess: () => {
+      navigate('/');
+    },
+  });
+
+  return deleteMutation;
+};
+
+export default useDeleteMember;

--- a/src/pages/UserInfoPage/components/UserInfoContainer.tsx
+++ b/src/pages/UserInfoPage/components/UserInfoContainer.tsx
@@ -14,7 +14,7 @@ const UserInfoContainer = () => {
   };
 
   return (
-    <div className='mt-14 flex w-[375px] flex-col justify-center'>
+    <div className='mt-10 flex w-[375px] flex-col justify-center'>
       <div className='mx-auto flex w-custom flex-col justify-center gap-10'>
         <UserInfoBox user={user} />
         <button

--- a/src/pages/UserMypage/components/UserButtonContainer.tsx
+++ b/src/pages/UserMypage/components/UserButtonContainer.tsx
@@ -6,7 +6,7 @@ import CategoryButton from './CategoryButton';
 import useGetLatestReservation from '../hooks/useGetLatestReservation';
 
 const UserButtonContainer = () => {
-  const { data: latestReservation } = useGetLatestReservation();
+  const { latestReservation } = useGetLatestReservation();
   const navigate = useNavigate();
 
   const handleMoveReservationList = () => {

--- a/src/pages/UserMypage/hooks/useGetLatestReservation.ts
+++ b/src/pages/UserMypage/hooks/useGetLatestReservation.ts
@@ -6,7 +6,7 @@ const useGetLatestReservation = () => {
     queryKey: ['latestReservation'],
     queryFn: () => getLatestReservation(),
   });
-  return { data };
+  return { latestReservation: data };
 };
 
 export default useGetLatestReservation;

--- a/src/pages/UserMypage/hooks/useGetUserData.ts
+++ b/src/pages/UserMypage/hooks/useGetUserData.ts
@@ -7,7 +7,7 @@ const useGetUserData = () => {
     queryKey: ['member'],
     queryFn: () => getUserData(),
   });
-  return { user: (data ?? []) as Member };
+  return { user: (data ?? {}) as Member };
 };
 
 export default useGetUserData;

--- a/src/pages/UserSignUp/components/UserSignUpForm.tsx
+++ b/src/pages/UserSignUp/components/UserSignUpForm.tsx
@@ -28,7 +28,7 @@ const UserSignUpForm = () => {
   // input 값 반영
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.name === 'nickname' && e.target.value.length > 8) {
-      e.target.value = e.target.value.substring(0, 8);
+      e.target.value = e.target.value.substring(0, 10);
     }
     setUserFormData({
       ...userFormData,

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -118,11 +118,11 @@ const router = createBrowserRouter([
     element: <HostNotiPage />,
   },
   {
-    path: 'host-info',
+    path: '/host-info',
     element: <HostInfoPage />,
   },
   {
-    path: 'host-info-edit',
+    path: '/host-info-edit',
     element: <HostInfoEditPage />,
   },
   {


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업자 정보 수정, 조회 페이지 및 회원 탈퇴 버튼 api 연결

## 📝 요구 사항과 구현 내용
- 사업자 정보 조회 페이지 api 연결
- 사업자 정보 수정 페이지 api 연결
  - 사업자 정보 수정 api 반환값 삭제 및 반환타입 변경
- 사용자, 사업자 탈퇴 버튼 api 연결

## ✅ 피드백 반영사항
- 사용자, 사업자 회원가입 폼에서 닉네임 substring 8에서 10으로 변경

## 💬 PR 포인트
- Router.tsx에서 사업자 정보 조회, 수정 페이지에 / 가 안 들어가 있어서 추가했습니다

## 🔗 연관된 이슈
- close #48 
- close #54 
- close #57