### PR TITLE
✨ Feat : 결제 취소 버튼 api 연결

### DIFF
--- a/src/apis/reservation.ts
+++ b/src/apis/reservation.ts
@@ -77,3 +77,13 @@ export const getPaymentsFail = async (
 
   return response.data;
 };
+
+// 결제 취소
+export const postCancelPayment = async (id: number): Promise<void> => {
+  await authInstance.post('/api/v1/payments/toss/cancel', {
+    params: {
+      reservationId: id,
+      cancelReason: '단순변심',
+    },
+  });
+};

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,6 @@
 interface ModalProps {
   message: string;
+  cancelPaymentMessage?: string;
   onCancelButtonClick: React.MouseEventHandler<HTMLButtonElement>;
   onConfirmButtonClick: React.MouseEventHandler<HTMLButtonElement>;
 }
@@ -8,11 +9,15 @@ const Modal = ({
   message,
   onCancelButtonClick,
   onConfirmButtonClick,
+  cancelPaymentMessage,
 }: ModalProps) => {
   return (
     <div className='fixed left-[50%] top-0 z-[1500] flex h-[100%] w-[375px] translate-x-[-50%] items-center justify-center bg-[rgba(0,0,0,0.4)]'>
       <div className='flex h-auto min-h-[140px] w-[280px] flex-col rounded-lg bg-[rgba(255,255,255,0.98)] text-center'>
-        <div className='flex h-auto min-h-[calc(100%-44px)] flex-grow items-center justify-center px-5 py-4'>
+        <div className='flex h-auto min-h-[calc(100%-44px)] flex-grow flex-col items-center justify-center whitespace-pre-line px-5 py-4'>
+          {cancelPaymentMessage && (
+            <span className='text-primary'>{cancelPaymentMessage}</span>
+          )}
           {message}
         </div>
         <div className='flex h-[44px] w-[100%] border-t-[0.5px] border-subfont'>

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -148,8 +148,8 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
         </div>
         {modalOpen && (
           <Modal
-            message={`${cancelPaymentText}
-            결제를 취소하시겠습니까?`}
+            message='결제를 취소하시겠습니까?'
+            cancelPaymentMessage={`${cancelPaymentText}`}
             onCancelButtonClick={() => setModalOpen(false)}
             onConfirmButtonClick={handleCancelPayment}
           />

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import Modal from '@components/Modal';
 import { Reservation } from '@typings/types';
 import { MdArrowForwardIos } from 'react-icons/md';
+import useCancelPayment from '../hooks/useCancelPayment';
 
 interface CancelPaymentText {
   buttonText: string;
@@ -26,6 +27,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
     reservationId,
   } = item;
   const navigate = useNavigate();
+  const { mutate: cancelPayment } = useCancelPayment();
 
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -71,7 +73,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
         reservationCreatedAt: `${getDateFunction(reservationCreatedAt)}`,
         reservationDay: `${getDateFunction(startTime)}`,
         reservationTime: `${getTimeFunction(startTime)} ~ ${getTimeFunction(endTime)}`,
-        studyRoomCapacity: `${reservationCapacity}`,
+        reservationCapacity: `${reservationCapacity}`,
         price: `${price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`,
         reservationId: `${reservationId}`,
       },
@@ -79,7 +81,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
   };
 
   const handleCancelPayment = () => {
-    console.log('결제 취소');
+    cancelPayment(reservationId);
     setModalOpen(() => false);
   };
 

--- a/src/pages/ReservationListPage/hooks/useCancelPayment.ts
+++ b/src/pages/ReservationListPage/hooks/useCancelPayment.ts
@@ -1,0 +1,18 @@
+import { postCancelPayment } from '@apis/reservation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useCancelPayment = () => {
+  const queryClient = useQueryClient();
+
+  const cancelPayment = useMutation({
+    mutationFn: (id: number) => postCancelPayment(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['myReservationList', 'latestReservation'],
+      });
+    },
+  });
+  return cancelPayment;
+};
+
+export default useCancelPayment;

--- a/src/pages/ReservationListPage/hooks/useCancelPayment.ts
+++ b/src/pages/ReservationListPage/hooks/useCancelPayment.ts
@@ -1,5 +1,6 @@
 import { postCancelPayment } from '@apis/reservation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 const useCancelPayment = () => {
   const queryClient = useQueryClient();
@@ -10,6 +11,7 @@ const useCancelPayment = () => {
       queryClient.invalidateQueries({
         queryKey: ['myReservationList', 'latestReservation'],
       });
+      toast.info('결제가 취소되었습니다.');
     },
   });
   return cancelPayment;

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -18,18 +18,18 @@ const LatestReservation = ({ data }: { data: Reservation }) => {
     <>
       <Link to='/reservation-list'>
         <div className='flex h-auto min-h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
-          <div className='flex items-center justify-start gap-[13px]'>
+          <div className='flex justify-start gap-[13px]'>
             <img
               src={workplaceImageUrl}
               alt='스터디룸 사진'
-              className='h-[118px] w-[118px] self-start bg-subfont object-cover'
+              className='h-[118px] w-[118px] bg-subfont object-cover'
             />
 
             <div className='flex w-[170px] flex-col gap-[7px]'>
               <span className='break-word text-[16px] font-medium'>
                 {workplaceName}
               </span>
-              <ul className='flex flex-col gap-[2px] text-[12px]'>
+              <ul className='flex flex-col gap-1 text-[12px]'>
                 <ListStyle
                   name='예약일'
                   value={getDateFunction(startTime)}

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -10,25 +10,25 @@ const LatestReservation = ({ data }: { data: Reservation }) => {
     studyRoomName,
     startTime,
     endTime,
-    studyRoomCapacity,
+    reservationCapacity,
     price,
   } = data;
 
   return (
     <>
       <Link to='/reservation-list'>
-        <div className='flex h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
-          <div className='flex items-center justify-start gap-[10px]'>
-            <div className='h-[118px] w-[118px]'>
-              <img
-                src={workplaceImageUrl}
-                alt='스터디룸 사진'
-                className='object-cover'
-              />
-            </div>
+        <div className='flex h-auto min-h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
+          <div className='flex items-center justify-start gap-[13px]'>
+            <img
+              src={workplaceImageUrl}
+              alt='스터디룸 사진'
+              className='h-[118px] w-[118px] self-start bg-subfont object-cover'
+            />
 
             <div className='flex w-[170px] flex-col gap-[7px]'>
-              <p className='text-[16px] font-medium'>{workplaceName}</p>
+              <span className='break-word text-[16px] font-medium'>
+                {workplaceName}
+              </span>
               <ul className='flex flex-col gap-[2px] text-[12px]'>
                 <ListStyle
                   name='예약일'
@@ -44,7 +44,7 @@ const LatestReservation = ({ data }: { data: Reservation }) => {
                 />
                 <ListStyle
                   name='인원'
-                  value={`${studyRoomCapacity} 인`}
+                  value={`${reservationCapacity}인`}
                 />
               </ul>
             </div>

--- a/src/pages/WriteReviewPage/components/ReservationInfo.tsx
+++ b/src/pages/WriteReviewPage/components/ReservationInfo.tsx
@@ -5,7 +5,7 @@ const ReservationInfo = ({ item }: { item: WriteReviewProps }) => {
   const {
     workPlaceName,
     reservationTime,
-    studyRoomCapacity,
+    reservationCapacity,
     price,
     reservationDay,
     reservationCreatedAt,
@@ -30,7 +30,7 @@ const ReservationInfo = ({ item }: { item: WriteReviewProps }) => {
         />
         <ListStyle
           name='인원'
-          value={studyRoomCapacity}
+          value={reservationCapacity}
         />
         <ListStyle
           name='금액'

--- a/src/pages/WriteReviewPage/index.tsx
+++ b/src/pages/WriteReviewPage/index.tsx
@@ -9,7 +9,7 @@ export interface WriteReviewProps {
   workPlaceName: string;
   reservationCreatedAt: string;
   reservationTime: string;
-  studyRoomCapacity: number;
+  reservationCapacity: number;
   price: string;
   reservationDay: string;
   studyRoomName: string;

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -86,7 +86,7 @@ export interface Reservation {
   reservationCreatedAt: string;
   startTime: string;
   endTime: string;
-  studyRoomCapacity: number;
+  reservationCapacity: number;
   price: number;
 }
 


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 결제 취소 api 연결

## 📝 요구 사항과 구현 내용
- 결제 취소 버튼 api 연결
- 결제 취소 48시간 전 -> '총 금액의 100%가 환불됩니다.'
  결제 취소 24시간 전 -> '총 금액의 50%가 환불됩니다.' 
- 결제 취소 문구 색상 변경이 필요해서 Modal 컴포넌트 수정
- 리뷰 작성 페이지 studyRoomCapacity -> reservationCapacity 로 변경

## ✅ 피드백 반영사항
- 결제 취소 성공 시 토스트 알림 추가 -> 결제 취소 api 완료된 후 테스트 필요합니다!

## 💬 PR 포인트
- 리뷰 작성 완료된 예약에서 리뷰 작성 버튼 제거하는 작업 추가적으로 필요합니다