### PR TITLE
✨ Feat : 스터디룸 상세 정보 페이지 기능 구현 완료

### DIFF
--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -151,10 +151,11 @@ export const getPossibleTime = async (
   studyRoomId: number,
   checkDate: Date,
 ): Promise<PossibleTime> => {
+  const formattedDate = checkDate.toISOString().split('T')[0];
   const response = await defaultInstance.get(
     `api/v1/studyroom/search/${studyRoomId}`,
     {
-      params: checkDate,
+      params: { checkDate: formattedDate },
     },
   );
   return response.data;

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -153,7 +153,9 @@ export const getBusinessWorkPlace =
 export const getStudyroomDetail = async (
   studyRoomId: number,
 ): Promise<StudyRoomDetailData> => {
-  const response = await defaultInstance.get(`api/v1/studyroom/${studyRoomId}`);
+  const response = await defaultInstance.get(
+    `/api/v1/studyroom/${studyRoomId}`,
+  );
   return response.data;
 };
 

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -7,6 +7,7 @@ import {
   SearchStudyRoom,
   SearchStudyRoomData,
   StudyRoomData,
+  StudyRoomDetailData,
   StudyRoomPutData,
   WorkPlaceData,
   WorkPlacePutData,
@@ -135,3 +136,11 @@ export const getBusinessWorkPlace =
     const response = await authInstance.get('/api/v1/workplace/business');
     return response.data;
   };
+
+// 스터디룸 상세 정보 조회
+export const getStudyroomDetail = async (
+  studyroomId: number,
+): Promise<StudyRoomDetailData> => {
+  const response = await authInstance.get(`api/v1/studyroom/${studyroomId}`);
+  return response.data;
+};

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -4,6 +4,7 @@ import {
   GetWorkPlaceData,
   MapPosition,
   NowPosition,
+  PossibleTime,
   SearchStudyRoom,
   SearchStudyRoomData,
   StudyRoomData,
@@ -139,8 +140,22 @@ export const getBusinessWorkPlace =
 
 // 스터디룸 상세 정보 조회
 export const getStudyroomDetail = async (
-  studyroomId: number,
+  studyRoomId: number,
 ): Promise<StudyRoomDetailData> => {
-  const response = await authInstance.get(`api/v1/studyroom/${studyroomId}`);
+  const response = await defaultInstance.get(`api/v1/studyroom/${studyRoomId}`);
+  return response.data;
+};
+
+// 스터디룸의 예약 가능한 시간대 조회
+export const getPossibleTime = async (
+  studyRoomId: number,
+  checkDate: Date,
+): Promise<PossibleTime> => {
+  const response = await defaultInstance.get(
+    `api/v1/studyroom/search/${studyRoomId}`,
+    {
+      params: checkDate,
+    },
+  );
   return response.data;
 };

--- a/src/pages/PaymentPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentPage/PaymentSuccessPage.tsx
@@ -18,10 +18,10 @@ const PaymentSuccessPage = () => {
         <div className='flex w-custom flex-col items-center justify-center gap-3'>
           <div className='text-xl font-medium'>결제 완료</div>
           <div>결제가 정상적으로 처리되었습니다.</div>
-          <div className='flex w-[220px] flex-col text-sm'>
+          <div className='mt-3 flex w-[220px] flex-col gap-1 text-sm'>
             <div className='flex justify-between'>
               <p className='font-medium'>주문 상품</p>
-              <p>{orderName}</p>
+              <p className='w-[150px] text-end'>{orderName}</p>
             </div>
             <div className='flex justify-between'>
               <p className='font-medium'>결제 금액</p>

--- a/src/pages/PaymentPage/components/CancelRule.tsx
+++ b/src/pages/PaymentPage/components/CancelRule.tsx
@@ -5,7 +5,7 @@ const CancelRule = () => {
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
       <DetailTitle title='취소 / 환불 규정' />
       <div className='flex flex-col gap-2 text-sm'>
-      <div className='flex items-center justify-between'>
+        <div className='flex items-center justify-between'>
           <span>이용 2일 전까지</span>
           <span className='font-normal'>총 금액의 100% 환불</span>
         </div>

--- a/src/pages/PaymentPage/components/CancelRule.tsx
+++ b/src/pages/PaymentPage/components/CancelRule.tsx
@@ -5,9 +5,13 @@ const CancelRule = () => {
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
       <DetailTitle title='취소 / 환불 규정' />
       <div className='flex flex-col gap-2 text-sm'>
+      <div className='flex items-center justify-between'>
+          <span>이용 2일 전까지</span>
+          <span className='font-normal'>총 금액의 100% 환불</span>
+        </div>
         <div className='flex items-center justify-between'>
           <span>이용 24시간 전까지</span>
-          <span className='font-normal'>총 금액의 100% 환불</span>
+          <span className='font-normal'>총 금액의 50% 환불</span>
         </div>
         <div className='flex items-center justify-between'>
           <span>이용 24시간 이내</span>

--- a/src/pages/PaymentPage/index.tsx
+++ b/src/pages/PaymentPage/index.tsx
@@ -1,6 +1,7 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
 import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import PaymentRoomCard from './components/PaymentRoomCard';
 import ReservationInfo from './components/ReservationInfo';
 import CancelRule from './components/CancelRule';
@@ -38,12 +39,8 @@ export interface CheckState {
 export type PayMethodType = 'TOSS' | 'KAKAOPAY' | null;
 
 const PaymentPage = () => {
-  const studyRoomInfo: StudyRoomInfo = {
-    studyRoomId: 309,
-    workplaceName: 'ABC 스터디룸',
-    studyRoomTitle: 'ROOM A',
-    studyRoomPrice: 3500,
-  };
+  const location = useLocation();
+  const studyRoomInfo = location.state;
 
   const [totalAmount, setTotalAmount] = useState(0);
 

--- a/src/pages/ReservationPage/components/ImageCarousel.tsx
+++ b/src/pages/ReservationPage/components/ImageCarousel.tsx
@@ -1,13 +1,14 @@
+import { StudyRoomDetailData } from '@typings/types';
 import { useState } from 'react';
 import { GrPrevious, GrNext } from 'react-icons/gr';
 
-const ImageCarousel = () => {
-  const roomImageList = [
-    'https://modo-phinf.pstatic.net/20180304_61/1520159998510ED9Yt_JPEG/mosaSDaCsR.jpeg?type=w1100',
-    'https://regainstudy.com/theme/basic/img/sub/sub3-1_img_01.jpg',
-    'https://img1.yna.co.kr/etc/inner/KR/2018/01/15/AKR20180115024900004_01_i_P4.jpg',
-    'https://d2v80xjmx68n4w.cloudfront.net/gigs/YhLlk1707054944.jpg',
-  ];
+interface ImageCarouselProps {
+  data: StudyRoomDetailData;
+}
+
+const ImageCarousel = (props: ImageCarouselProps) => {
+  const { data } = props;
+  const roomImageList = data.imageUrl;
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const showSlide = (index: number) => {
@@ -32,15 +33,19 @@ const ImageCarousel = () => {
   return (
     <>
       <div className='relative mx-auto mt-8 w-custom'>
-        <img
-          src={roomImageList[currentSlide]}
-          alt='룸 사진'
-          className='pointer-events-none h-[240px] w-full select-none object-cover'
-        />
-        <div className='absolute top-[100px] flex w-custom items-center justify-between text-4xl text-white opacity-70'>
-          <GrPrevious onClick={handleSlidePrev} />
-          <GrNext onClick={handleSlideNext} />
-        </div>
+        {roomImageList && roomImageList.length > 0 && (
+          <>
+            <img
+              src={roomImageList[currentSlide]}
+              alt='룸 사진'
+              className='pointer-events-none h-[240px] w-full select-none object-cover'
+            />
+            <div className='absolute top-[100px] flex w-custom items-center justify-between text-4xl text-white opacity-70'>
+              <GrPrevious onClick={handleSlidePrev} />
+              <GrNext onClick={handleSlideNext} />
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/src/pages/ReservationPage/components/ReservationBar.tsx
+++ b/src/pages/ReservationPage/components/ReservationBar.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import ReservationDate from './ReservationDate/ReservationDate';
 import ReservationTime from './ReservationTime';
 import ReservationPeople from './ReservationPeople';
-import useGetPossibleTime from '../hooks/useGetPossibleTime';
+import { useGetPossibleTime } from '../hooks/useGetPossibleTime';
 
 interface ReservationBarProps {
   studyroomId: number;
@@ -101,7 +101,7 @@ const ReservationBar = (props: ReservationBarProps) => {
         >
           {formattedPeople}
         </button>
-        {showSelect.date && <ReservationDate />}
+        {showSelect.date && <ReservationDate studyroomId={studyroomId} />}
         {showSelect.time && <ReservationTime data={data} />}
         {showSelect.people && <ReservationPeople data={data} />}
       </div>

--- a/src/pages/ReservationPage/components/ReservationBar.tsx
+++ b/src/pages/ReservationPage/components/ReservationBar.tsx
@@ -14,8 +14,6 @@ const ReservationBar = (props: ReservationBarProps) => {
   const { searchDate, searchTime, searchPeople } = useSearchStore();
   const { data } = useGetPossibleTime(studyroomId, searchDate);
 
-  console.log(data);
-
   const [showSelect, setShowSelect] = useState({
     date: false,
     time: false,

--- a/src/pages/ReservationPage/components/ReservationBar.tsx
+++ b/src/pages/ReservationPage/components/ReservationBar.tsx
@@ -3,9 +3,17 @@ import { useEffect, useRef, useState } from 'react';
 import ReservationDate from './ReservationDate/ReservationDate';
 import ReservationTime from './ReservationTime';
 import ReservationPeople from './ReservationPeople';
+import useGetPossibleTime from '../hooks/useGetPossibleTime';
 
-const ReservationBar = () => {
+interface ReservationBarProps {
+  studyroomId: number;
+}
+
+const ReservationBar = (props: ReservationBarProps) => {
+  const { studyroomId } = props;
   const { searchDate, searchTime, searchPeople } = useSearchStore();
+  const { data } = useGetPossibleTime(studyroomId, searchDate);
+
   const [showSelect, setShowSelect] = useState({
     date: false,
     time: false,
@@ -94,8 +102,8 @@ const ReservationBar = () => {
           {formattedPeople}
         </button>
         {showSelect.date && <ReservationDate />}
-        {showSelect.time && <ReservationTime />}
-        {showSelect.people && <ReservationPeople />}
+        {showSelect.time && <ReservationTime data={data} />}
+        {showSelect.people && <ReservationPeople data={data} />}
       </div>
     </>
   );

--- a/src/pages/ReservationPage/components/ReservationBar.tsx
+++ b/src/pages/ReservationPage/components/ReservationBar.tsx
@@ -14,6 +14,8 @@ const ReservationBar = (props: ReservationBarProps) => {
   const { searchDate, searchTime, searchPeople } = useSearchStore();
   const { data } = useGetPossibleTime(studyroomId, searchDate);
 
+  console.log(data);
+
   const [showSelect, setShowSelect] = useState({
     date: false,
     time: false,

--- a/src/pages/ReservationPage/components/ReservationDate/ReservationDate.css
+++ b/src/pages/ReservationPage/components/ReservationDate/ReservationDate.css
@@ -79,6 +79,11 @@
   color: #c3c3c3;
 }
 
+/* 이전 날짜 */
+.react-calendar__tile:disabled {
+  color: #c3c3c3;
+}
+
 /* 호버됐을 때 색상 */
 .react-calendar__tile:enabled:hover {
   position: relative;

--- a/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
+++ b/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
@@ -15,17 +15,13 @@ const ReservationDate = (props: ReservationDateProps) => {
   const { studyroomId } = props;
   const { searchDate, setDate, setTime, setFormattedTime } = useSearchStore();
   const { mutate } = usePossibleTimeMutation();
-  useEffect(() => {
-    if (searchDate) {
-      mutate({ studyRoomId: studyroomId, checkDate: searchDate });
-      setTime([]);
-      setFormattedTime([]);
-    }
-  }, [searchDate, studyroomId, mutate, setTime, setFormattedTime]);
 
   const handleChangeDate = (newDate: SelectedDate) => {
     if (newDate instanceof Date) {
       setDate(newDate);
+      mutate({ studyRoomId: studyroomId, checkDate: newDate });
+      setTime([]);
+      setFormattedTime([]);
     }
   };
   return (
@@ -39,6 +35,7 @@ const ReservationDate = (props: ReservationDateProps) => {
         prev2Label={null}
         next2Label={null}
         showFixedNumberOfWeeks
+        minDate={new Date()}
       />
     </div>
   );

--- a/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
+++ b/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
@@ -3,7 +3,6 @@ import './ReservationDate.css';
 import moment from 'moment';
 import useSearchStore from '@store/searchStore';
 import { usePossibleTimeMutation } from '@pages/ReservationPage/hooks/useGetPossibleTime';
-import { useEffect } from 'react';
 
 type DatePiece = Date | null;
 type SelectedDate = DatePiece | [DatePiece, DatePiece];

--- a/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
+++ b/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
@@ -2,16 +2,24 @@ import Calendar from 'react-calendar';
 import './ReservationDate.css';
 import moment from 'moment';
 import useSearchStore from '@store/searchStore';
+import { usePossibleTimeMutation } from '@pages/ReservationPage/hooks/useGetPossibleTime';
 
 type DatePiece = Date | null;
-
 type SelectedDate = DatePiece | [DatePiece, DatePiece];
+interface ReservationDateProps {
+  studyroomId: number;
+}
 
-const ReservationDate = () => {
+const ReservationDate = (props: ReservationDateProps) => {
+  const { studyroomId } = props;
   const { searchDate, setDate } = useSearchStore();
+  const { mutate } = usePossibleTimeMutation();
+  mutate({ studyRoomId: studyroomId, checkDate: searchDate });
+
   const handleChangeDate = (newDate: SelectedDate) => {
     if (newDate instanceof Date) {
       setDate(new Date(newDate));
+      mutate({ studyRoomId: studyroomId, checkDate: new Date(newDate) });
     }
   };
   return (

--- a/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
+++ b/src/pages/ReservationPage/components/ReservationDate/ReservationDate.tsx
@@ -3,6 +3,7 @@ import './ReservationDate.css';
 import moment from 'moment';
 import useSearchStore from '@store/searchStore';
 import { usePossibleTimeMutation } from '@pages/ReservationPage/hooks/useGetPossibleTime';
+import { useEffect } from 'react';
 
 type DatePiece = Date | null;
 type SelectedDate = DatePiece | [DatePiece, DatePiece];
@@ -12,14 +13,19 @@ interface ReservationDateProps {
 
 const ReservationDate = (props: ReservationDateProps) => {
   const { studyroomId } = props;
-  const { searchDate, setDate } = useSearchStore();
+  const { searchDate, setDate, setTime, setFormattedTime } = useSearchStore();
   const { mutate } = usePossibleTimeMutation();
-  mutate({ studyRoomId: studyroomId, checkDate: searchDate });
+  useEffect(() => {
+    if (searchDate) {
+      mutate({ studyRoomId: studyroomId, checkDate: searchDate });
+      setTime([]);
+      setFormattedTime([]);
+    }
+  }, [searchDate, studyroomId, mutate, setTime, setFormattedTime]);
 
   const handleChangeDate = (newDate: SelectedDate) => {
     if (newDate instanceof Date) {
-      setDate(new Date(newDate));
-      mutate({ studyRoomId: studyroomId, checkDate: new Date(newDate) });
+      setDate(newDate);
     }
   };
   return (

--- a/src/pages/ReservationPage/components/ReservationPeople.tsx
+++ b/src/pages/ReservationPage/components/ReservationPeople.tsx
@@ -1,13 +1,19 @@
 import { AiOutlineMinus, AiOutlinePlus } from 'react-icons/ai';
 import useSearchStore from '@store/searchStore';
+import { PossibleTime } from '@typings/types';
 
-const ReservationPeople = () => {
+interface ReservationPeopleProps {
+  data: PossibleTime;
+}
+
+const ReservationPeople = (props: ReservationPeopleProps) => {
+  const { data } = props;
   const { searchPeople, setPeople } = useSearchStore();
 
   const handleCountClick = (count: string) => {
     if (count === 'decrease' && searchPeople > 0) {
       setPeople(searchPeople - 1);
-    } else if (count === 'increase') {
+    } else if (count === 'increase' && searchPeople < data.capacity) {
       setPeople(searchPeople + 1);
     }
   };

--- a/src/pages/ReservationPage/components/ReservationTime.tsx
+++ b/src/pages/ReservationPage/components/ReservationTime.tsx
@@ -1,8 +1,14 @@
 import useSearchStore from '@store/searchStore';
+import { PossibleTime } from '@typings/types';
 
-const ReservationTime = () => {
+interface ReservationTimeProps {
+  data: PossibleTime;
+}
+
+const ReservationTime = (props: ReservationTimeProps) => {
+  const { data } = props;
   const { searchTime, setTime, setFormattedTime } = useSearchStore();
-  const times = { startTime: '09:00', endTime: '23:00' };
+  const times = { startTime: data.startTime, endTime: data.endTime };
 
   const startHour: number = Number(times.startTime.split(':')[0]);
   const endHour: number = Number(times.endTime.split(':')[0]);

--- a/src/pages/ReservationPage/components/ReservationTime.tsx
+++ b/src/pages/ReservationPage/components/ReservationTime.tsx
@@ -21,6 +21,9 @@ const ReservationTime = (props: ReservationTimeProps) => {
   const possibleTimeList = data.possibleTime;
 
   const setTimeArray = (newArray: string[]) => {
+    if (newArray.length === 0) {
+      return;
+    }
     const lastTime = newArray[newArray.length - 1];
     const [hour] = lastTime.split(':');
     const newTimeArray = [newArray[0], `${hour}:59`];

--- a/src/pages/ReservationPage/components/ReservationTime.tsx
+++ b/src/pages/ReservationPage/components/ReservationTime.tsx
@@ -89,8 +89,11 @@ const ReservationTime = (props: ReservationTimeProps) => {
   };
 
   return (
-    <div className='absolute top-20 flex flex-col gap-[4px] rounded-[10px] bg-white shadow-custom'>
-      <div className='flex w-[330px] flex-wrap items-center justify-center gap-[6px] py-3'>
+    <div className='absolute top-20 flex w-[330px] flex-col items-center gap-[4px] rounded-[10px] bg-white shadow-custom'>
+      <div className='flex w-[330px] items-center justify-end px-3 pt-3 text-xs font-medium text-primary'>
+        * 최소 2시간 예약 가능
+      </div>
+      <div className='flex w-[304px] flex-wrap items-center gap-[6px] pb-3 pt-2'>
         {timeList.map((timeItem: string) => (
           <button
             key={timeItem}

--- a/src/pages/ReservationPage/components/ReservationTime.tsx
+++ b/src/pages/ReservationPage/components/ReservationTime.tsx
@@ -8,7 +8,8 @@ interface ReservationTimeProps {
 const ReservationTime = (props: ReservationTimeProps) => {
   const { data } = props;
   const { searchTime, setTime, setFormattedTime } = useSearchStore();
-  const times = { startTime: data.startTime, endTime: data.endTime };
+  // const times = { startTime: data.startTime, endTime: data.endTime };
+  const times = { startTime: '09:00', endTime: '23:00' };
 
   const startHour: number = Number(times.startTime.split(':')[0]);
   const endHour: number = Number(times.endTime.split(':')[0]);
@@ -18,6 +19,19 @@ const ReservationTime = (props: ReservationTimeProps) => {
     return `${String(hour).padStart(2, '0')}:00`;
   });
 
+  // const possibleTimeList = data.possibleTime;
+  const possibleTimeList = [
+    '09:00',
+    '13:00',
+    '14:00',
+    '15:00',
+    '18:00',
+    '19:00',
+    '20:00',
+    '21:00',
+    '22:00',
+  ];
+
   const setTimeArray = (newArray: string[]) => {
     const lastTime = newArray[newArray.length - 1];
     const [hour] = lastTime.split(':');
@@ -25,27 +39,35 @@ const ReservationTime = (props: ReservationTimeProps) => {
     setFormattedTime(newTimeArray);
   };
 
+  const setTimePossible = (selectedTimes: string[]) => {
+    // selectedTimes가 possibleTimeList에 포함된 시간만 있는지 확인
+    if (selectedTimes.every((item) => possibleTimeList.includes(item))) {
+      setTime(selectedTimes);
+      setTimeArray(selectedTimes);
+    }
+  };
+
   const handleSelectTime = (time: string) => {
+    if (!possibleTimeList.find((item) => item === time)) {
+      return;
+    }
     const indexOfTime = timeList.indexOf(time);
     if (searchTime.length === 0) {
       const slicedSelected = [...timeList].splice(indexOfTime, 2); // 기본 2시간
-      setTime(slicedSelected);
-      setTimeArray(slicedSelected);
+      setTimePossible(slicedSelected);
     } else {
       const indexOfSelected = searchTime.indexOf(time);
       if (indexOfSelected === 0 && searchTime.length > 2) {
         // 선택되어있는 것들 중에서 첫번째 시간을 선택했을 경우 (2시간 미만이 아니라면)
         const slicedSelected = searchTime.filter((item) => item !== time);
-        setTime(slicedSelected);
-        setTimeArray(slicedSelected);
+        setTimePossible(slicedSelected);
       } else if (indexOfSelected !== -1 && indexOfSelected !== 1) {
         // 선택되어있는 것들 중에서 하나를 선택했을 경우
         // 2번째 시간은 선택되지 않아야 함 (2시간 미만)
         // 선택된 시간이 2시간일 때, 첫번째 시간을 선택했을 경우
         const slicedSelected = [...searchTime];
         slicedSelected.splice(indexOfSelected);
-        setTime(slicedSelected);
-        setTimeArray(slicedSelected);
+        setTimePossible(slicedSelected);
       } else if (
         indexOfTime > timeList.indexOf(searchTime[searchTime.length - 1])
       ) {
@@ -54,16 +76,14 @@ const ReservationTime = (props: ReservationTimeProps) => {
           timeList.indexOf(searchTime[0]),
           indexOfTime + 1,
         );
-        setTime(addAfterSelected);
-        setTimeArray(addAfterSelected);
+        setTimePossible(addAfterSelected);
       } else if (indexOfTime < timeList.indexOf(searchTime[0])) {
         // 선택되어있는 시간 이전 시간을 선택했을 경우
         const addBeforeSelected = [...timeList].slice(
           indexOfTime,
           timeList.indexOf(searchTime[searchTime.length - 1]) + 1,
         );
-        setTime(addBeforeSelected);
-        setTimeArray(addBeforeSelected);
+        setTimePossible(addBeforeSelected);
       }
     }
   };
@@ -75,7 +95,7 @@ const ReservationTime = (props: ReservationTimeProps) => {
           <button
             key={timeItem}
             type='button'
-            className={`flex h-[30px] w-[56px] items-center justify-center rounded-[5px] border-[1px] border-subfont px-[14px] py-[6px] text-xs ${searchTime.find((item) => item === timeItem) ? 'bg-primary text-white' : 'bg-white'}`}
+            className={`flex h-[30px] w-[56px] items-center justify-center rounded-[5px] border-[1px] border-subfont px-[14px] py-[6px] text-xs ${possibleTimeList.find((item) => item === timeItem) ? '' : 'pointer-events-none bg-[#C3C3C3] text-[#454545]'} ${searchTime.find((item) => item === timeItem) ? 'bg-primary text-white' : 'bg-white'} `}
             onClick={() => handleSelectTime(timeItem)}
           >
             {timeItem}

--- a/src/pages/ReservationPage/components/ReservationTime.tsx
+++ b/src/pages/ReservationPage/components/ReservationTime.tsx
@@ -8,8 +8,7 @@ interface ReservationTimeProps {
 const ReservationTime = (props: ReservationTimeProps) => {
   const { data } = props;
   const { searchTime, setTime, setFormattedTime } = useSearchStore();
-  // const times = { startTime: data.startTime, endTime: data.endTime };
-  const times = { startTime: '09:00', endTime: '23:00' };
+  const times = { startTime: data.startTime, endTime: data.endTime };
 
   const startHour: number = Number(times.startTime.split(':')[0]);
   const endHour: number = Number(times.endTime.split(':')[0]);
@@ -19,18 +18,7 @@ const ReservationTime = (props: ReservationTimeProps) => {
     return `${String(hour).padStart(2, '0')}:00`;
   });
 
-  // const possibleTimeList = data.possibleTime;
-  const possibleTimeList = [
-    '09:00',
-    '13:00',
-    '14:00',
-    '15:00',
-    '18:00',
-    '19:00',
-    '20:00',
-    '21:00',
-    '22:00',
-  ];
+  const possibleTimeList = data.possibleTime;
 
   const setTimeArray = (newArray: string[]) => {
     const lastTime = newArray[newArray.length - 1];

--- a/src/pages/ReservationPage/components/RoomDetail.tsx
+++ b/src/pages/ReservationPage/components/RoomDetail.tsx
@@ -11,17 +11,32 @@ const RoomDetail = (props: RoomDatailProps) => {
   const { data } = props;
   const navigate = useNavigate();
   return (
-    <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
-      <DetailTitle title='룸 상세 정보'>
-        <button
-          type='button'
-          className='flex items-center justify-center gap-1 text-xs text-subfont'
-          onClick={() => navigate(`/detail/${data.workplaceId}`)}
-        >
-          {data.workplaceName} <GrNext />
-        </button>
-      </DetailTitle>
-      <div className='whitespace-pre-wrap text-sm'>{data.description}</div>
+    <div className='mx-auto my-8 flex w-custom flex-col gap-6'>
+      <div className='flex flex-col gap-4'>
+        <DetailTitle title='룸 상세 정보'>
+          <button
+            type='button'
+            className='flex items-center justify-center gap-1 text-xs text-subfont'
+            onClick={() => navigate(`/detail/${data.workplaceId}`)}
+          >
+            {data.workplaceName} <GrNext />
+          </button>
+        </DetailTitle>
+        <div className='whitespace-pre-wrap text-sm'>{data.description}</div>
+      </div>
+      <div className='flex flex-col gap-4 pb-[110px]'>
+        <DetailTitle title='이용 정보' />
+        <div className='flex flex-col gap-2'>
+          <div className='flex items-center justify-between text-sm'>
+            <p className='font-medium'>1인당 1시간 이용 가격</p>
+            <p>{data.price.toLocaleString('ko-KR')}원</p>
+          </div>
+          <div className='flex items-center justify-between text-sm'>
+            <p className='font-medium'>수용 가능 인원</p>
+            <p>{data.capacity}명</p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/ReservationPage/components/RoomDetail.tsx
+++ b/src/pages/ReservationPage/components/RoomDetail.tsx
@@ -29,7 +29,7 @@ const RoomDetail = (props: RoomDatailProps) => {
         <div className='flex flex-col gap-2'>
           <div className='flex items-center justify-between text-sm'>
             <p className='font-medium'>1인당 1시간 이용 가격</p>
-            <p>{data.price.toLocaleString('ko-KR')}원</p>
+            <p>{data && data.price && data.price.toLocaleString('ko-KR')}원</p>
           </div>
           <div className='flex items-center justify-between text-sm'>
             <p className='font-medium'>수용 가능 인원</p>

--- a/src/pages/ReservationPage/components/RoomDetail.tsx
+++ b/src/pages/ReservationPage/components/RoomDetail.tsx
@@ -1,28 +1,27 @@
 import DetailTitle from '@components/DetailTitle';
+import { StudyRoomDetailData } from '@typings/types';
 import { GrNext } from 'react-icons/gr';
+import { useNavigate } from 'react-router-dom';
 
-const RoomDetail = () => {
+interface RoomDatailProps {
+  data: StudyRoomDetailData;
+}
+
+const RoomDetail = (props: RoomDatailProps) => {
+  const { data } = props;
+  const navigate = useNavigate();
   return (
     <div className='mx-auto mt-8 flex w-custom flex-col gap-4'>
       <DetailTitle title='룸 상세 정보'>
         <button
           type='button'
           className='flex items-center justify-center gap-1 text-xs text-subfont'
+          onClick={() => navigate(`/detail/${data.workplaceId}`)}
         >
-          123 스터디룸 <GrNext />
+          {data.workplaceName} <GrNext />
         </button>
       </DetailTitle>
-      <div className='whitespace-pre-wrap text-sm'>
-        강서구 내발산동 수명산파크 중심상가에 위치해있으며, 김포공항, 마곡,
-        마곡나루, 우장산, 화곡역 등에 가깝고 대로변에 위치하고 있어 접근성이
-        매우 용이합니다. <br />
-        관리자가 늦은 오후~새벽까지 상주하고 있어, 관리가 잘 되고 안전하게
-        이용하실 수 있습니다. <br />
-        스터디룸은 예약제로 운영중입니다.. * 간혹, 선예약이 있는 경우라도 조정을
-        통해, 최대한 이용하실 수 있는 방법을 찾을 수 있으니 전화나 톡톡으로
-        문의주시기 바랍니다. * 스터디존(1인석)은 총 60석으로 방문선착순
-        이용가능합니다.
-      </div>
+      <div className='whitespace-pre-wrap text-sm'>{data.description}</div>
     </div>
   );
 };

--- a/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
+++ b/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
@@ -1,8 +1,10 @@
 import { getPossibleTime } from '@apis/workplace';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PossibleTime } from '@typings/types';
 
-const useGetPossibleTime = (studyRoomId: number, checkDate: Date) => {
+type ModifyDateType = { studyRoomId: number; checkDate: Date };
+
+export const useGetPossibleTime = (studyRoomId: number, checkDate: Date) => {
   const { data, isLoading, isError } = useQuery<PossibleTime>({
     queryKey: ['studyroomDetail', studyRoomId, checkDate],
     queryFn: () => getPossibleTime(studyRoomId, checkDate),
@@ -11,4 +13,17 @@ const useGetPossibleTime = (studyRoomId: number, checkDate: Date) => {
   return { data: (data ?? {}) as PossibleTime, isLoading, isError };
 };
 
-export default useGetPossibleTime;
+export const usePossibleTimeMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<PossibleTime, Error, ModifyDateType>({
+    mutationFn: ({ studyRoomId, checkDate }) =>
+      getPossibleTime(studyRoomId, checkDate),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['studyroomDetail'] });
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+};

--- a/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
+++ b/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
@@ -1,0 +1,14 @@
+import { getPossibleTime } from '@apis/workplace';
+import { useQuery } from '@tanstack/react-query';
+import { PossibleTime } from '@typings/types';
+
+const useGetPossibleTime = (studyRoomId: number, checkDate: Date) => {
+  const { data, isLoading, isError } = useQuery<PossibleTime>({
+    queryKey: ['studyroomDetail', studyRoomId, checkDate],
+    queryFn: () => getPossibleTime(studyRoomId, checkDate),
+  });
+
+  return { data: (data ?? {}) as PossibleTime, isLoading, isError };
+};
+
+export default useGetPossibleTime;

--- a/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
+++ b/src/pages/ReservationPage/hooks/useGetPossibleTime.ts
@@ -19,8 +19,11 @@ export const usePossibleTimeMutation = () => {
   return useMutation<PossibleTime, Error, ModifyDateType>({
     mutationFn: ({ studyRoomId, checkDate }) =>
       getPossibleTime(studyRoomId, checkDate),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['studyroomDetail'] });
+    onSuccess: (_, variables) => {
+      const { studyRoomId, checkDate } = variables;
+      queryClient.invalidateQueries({
+        queryKey: ['studyroomDetail', studyRoomId, checkDate],
+      });
     },
     onError: (error) => {
       console.log(error);

--- a/src/pages/ReservationPage/hooks/useGetStudyroomDetail.ts
+++ b/src/pages/ReservationPage/hooks/useGetStudyroomDetail.ts
@@ -2,13 +2,13 @@ import { getStudyroomDetail } from '@apis/workplace';
 import { useQuery } from '@tanstack/react-query';
 import { StudyRoomDetailData } from '@typings/types';
 
-const useGetStudyroomDetail = (studyroomId: number) => {
+const useGetStudyroomDetail = (studyRoomId: number) => {
   const { data, isLoading, isError } = useQuery<StudyRoomDetailData>({
-    queryKey: ['studyroomDetail', studyroomId],
-    queryFn: () => getStudyroomDetail(studyroomId),
+    queryKey: ['studyroomDetail', studyRoomId],
+    queryFn: () => getStudyroomDetail(studyRoomId),
   });
 
-  return { data: (data ?? []) as StudyRoomDetailData, isLoading, isError };
+  return { data: (data ?? {}) as StudyRoomDetailData, isLoading, isError };
 };
 
 export default useGetStudyroomDetail;

--- a/src/pages/ReservationPage/hooks/useGetStudyroomDetail.ts
+++ b/src/pages/ReservationPage/hooks/useGetStudyroomDetail.ts
@@ -1,0 +1,14 @@
+import { getStudyroomDetail } from '@apis/workplace';
+import { useQuery } from '@tanstack/react-query';
+import { StudyRoomDetailData } from '@typings/types';
+
+const useGetStudyroomDetail = (studyroomId: number) => {
+  const { data, isLoading, isError } = useQuery<StudyRoomDetailData>({
+    queryKey: ['studyroomDetail', studyroomId],
+    queryFn: () => getStudyroomDetail(studyroomId),
+  });
+
+  return { data: (data ?? []) as StudyRoomDetailData, isLoading, isError };
+};
+
+export default useGetStudyroomDetail;

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -1,6 +1,6 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
@@ -8,28 +8,15 @@ import useGetStudyroomDetail from './hooks/useGetStudyroomDetail';
 
 const ReservationPage = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const studyroomId = Number(searchParams.get('studyroomId'));
-  const { data } = useGetStudyroomDetail(studyroomId);
+  const { studyroomId } = useParams<{ studyroomId: string }>();
+  const { data } = useGetStudyroomDetail(Number(studyroomId));
   console.log(data);
-  // const data = {
-  //   studyRoomId: 1,
-  //   workplaceId: 1,
-  //   workplaceName: '타임유스터디카페 민락점',
-  //   studyRoomName: 'Room A',
-  //   description: '조용하고 쾌적한 환경, 최대 4인 가능',
-  //   imageUrl: [
-  //     'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-1.jpg',
-  //     'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-2.jpg',
-  //   ],
-  //   price: 7000,
-  //   capacity: 4,
-  // };
+  console.log(Number(studyroomId));
 
   return (
     <MainLayout>
       <HeaderOnlyTitle title={data?.studyRoomName || '스터디룸'} />
-      <ReservationBar studyroomId={studyroomId} />
+      <ReservationBar studyroomId={Number(studyroomId)} />
       <ImageCarousel data={data} />
       <RoomDetail data={data} />
       <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -14,6 +14,13 @@ const ReservationPage = () => {
   const { data } = useGetStudyroomDetail(Number(studyroomId));
   const { searchTime, searchPeople } = useSearchStore();
 
+  const studyRoomInfo = {
+    studyRoomId: studyroomId,
+    workplaceName: data.workplaceName,
+    studyRoomTitle: data.studyRoomName,
+    studyRoomPrice: data.price,
+  };
+
   const handleClickReservation = () => {
     if (searchTime.length === 0) {
       toast.error('시간을 선택해주세요.');
@@ -23,7 +30,7 @@ const ReservationPage = () => {
       toast.error('인원을 선택해주세요.');
       return;
     }
-    navigate('/payment');
+    navigate('/payment', { state: studyRoomInfo });
   };
 
   return (

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -4,13 +4,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
-import useGetStudyroomDetail from './hooks/useGetStudyroomDetail';
 
 const ReservationPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const studyroomId = searchParams.get('studyroomId');
-  // const { data } = useGetStudyroomDetail(Number(studyroomId));
+  const studyroomId = Number(searchParams.get('studyroomId'));
+  // const { data } = useGetStudyroomDetail(studyroomId);
   const data = {
     studyRoomId: 1,
     workplaceId: 1,
@@ -28,7 +27,7 @@ const ReservationPage = () => {
   return (
     <MainLayout>
       <HeaderOnlyTitle title={data?.studyRoomName || '스터디룸'} />
-      <ReservationBar />
+      <ReservationBar studyroomId={studyroomId} />
       <ImageCarousel data={data} />
       <RoomDetail data={data} />
       <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -1,6 +1,8 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
 import { useNavigate, useParams } from 'react-router-dom';
+import useSearchStore from '@store/searchStore';
+import { toast } from 'react-toastify';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
@@ -10,8 +12,19 @@ const ReservationPage = () => {
   const navigate = useNavigate();
   const { studyroomId } = useParams<{ studyroomId: string }>();
   const { data } = useGetStudyroomDetail(Number(studyroomId));
-  console.log(data);
-  console.log(Number(studyroomId));
+  const { searchTime, searchPeople } = useSearchStore();
+
+  const handleClickReservation = () => {
+    if (searchTime.length === 0) {
+      toast.error('시간을 선택해주세요.');
+      return;
+    }
+    if (searchPeople === 0) {
+      toast.error('인원을 선택해주세요.');
+      return;
+    }
+    navigate('/payment');
+  };
 
   return (
     <MainLayout>
@@ -23,7 +36,7 @@ const ReservationPage = () => {
         <button
           type='button'
           className='btn-primary'
-          onClick={() => navigate('/payment')}
+          onClick={handleClickReservation}
         >
           예약하기
         </button>

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -1,18 +1,35 @@
 import HeaderOnlyTitle from '@layouts/HeaderOnlyTitle';
 import MainLayout from '@layouts/MainLayout';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
+import useGetStudyroomDetail from './hooks/useGetStudyroomDetail';
 
 const ReservationPage = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const studyroomId = searchParams.get('studyroomId');
+  // const { data } = useGetStudyroomDetail(Number(studyroomId));
+  const data = {
+    studyRoomId: 1,
+    workplaceId: 1,
+    workplaceName: '타임유스터디카페 민락점',
+    studyRoomName: 'Room A',
+    description: '조용하고 쾌적한 환경, 최대 4인 가능',
+    imageUrl: [
+      'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-1.jpg',
+      'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-2.jpg',
+    ],
+    price: 7000,
+    capacity: 4,
+  };
   return (
     <MainLayout>
-      <HeaderOnlyTitle title='ROOM B' />
+      <HeaderOnlyTitle title={data?.studyRoomName || '스터디룸'} />
       <ReservationBar />
-      <ImageCarousel />
-      <RoomDetail />
+      <ImageCarousel data={data} />
+      <RoomDetail data={data} />
       <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>
         <button
           type='button'

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -24,6 +24,7 @@ const ReservationPage = () => {
     price: 7000,
     capacity: 4,
   };
+
   return (
     <MainLayout>
       <HeaderOnlyTitle title={data?.studyRoomName || '스터디룸'} />

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -4,25 +4,27 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
+import useGetStudyroomDetail from './hooks/useGetStudyroomDetail';
 
 const ReservationPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const studyroomId = Number(searchParams.get('studyroomId'));
-  // const { data } = useGetStudyroomDetail(studyroomId);
-  const data = {
-    studyRoomId: 1,
-    workplaceId: 1,
-    workplaceName: '타임유스터디카페 민락점',
-    studyRoomName: 'Room A',
-    description: '조용하고 쾌적한 환경, 최대 4인 가능',
-    imageUrl: [
-      'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-1.jpg',
-      'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-2.jpg',
-    ],
-    price: 7000,
-    capacity: 4,
-  };
+  const { data } = useGetStudyroomDetail(studyroomId);
+  console.log(data);
+  // const data = {
+  //   studyRoomId: 1,
+  //   workplaceId: 1,
+  //   workplaceName: '타임유스터디카페 민락점',
+  //   studyRoomName: 'Room A',
+  //   description: '조용하고 쾌적한 환경, 최대 4인 가능',
+  //   imageUrl: [
+  //     'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-1.jpg',
+  //     'https://elasticbeanstalk-ap-northeast-2-405894845535.s3.ap-northeast-2.amazonaws.com/타임유스터디카페 민락점/Room A/Room A-2.jpg',
+  //   ],
+  //   price: 7000,
+  //   capacity: 4,
+  // };
 
   return (
     <MainLayout>

--- a/src/pages/SearchPage/components/SelectTime.tsx
+++ b/src/pages/SearchPage/components/SelectTime.tsx
@@ -70,6 +70,9 @@ const SelectTime = () => {
       >
         시간 선택
       </label>
+      <div className='flex w-[330px] items-center justify-end pb-2 text-xs font-medium text-primary'>
+        * 최소 2시간 예약 가능
+      </div>
       <div className='flex w-[330px] flex-wrap gap-x-[5px] gap-y-[10px]'>
         {timeList.map((timeItem: string) => (
           <button

--- a/src/pages/SearchPage/components/SelectTime.tsx
+++ b/src/pages/SearchPage/components/SelectTime.tsx
@@ -13,6 +13,9 @@ const SelectTime = () => {
   });
 
   const setTimeArray = (newArray: string[]) => {
+    if (newArray.length === 0) {
+      return;
+    }
     const lastTime = newArray[newArray.length - 1];
     const [hour] = lastTime.split(':');
     const newTimeArray = [newArray[0], `${hour}:59`];

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -134,7 +134,7 @@ const router = createBrowserRouter([
     element: <SearchResult />,
   },
   {
-    path: '/reservation/:reservationId',
+    path: '/reservation/:studyroomId',
     element: <ReservationPage />,
   },
   {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -134,7 +134,7 @@ const router = createBrowserRouter([
     element: <SearchResult />,
   },
   {
-    path: '/reservation',
+    path: '/reservation/:reservationId',
     element: <ReservationPage />,
   },
   {

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -134,6 +134,18 @@ export interface WorkplaceStudyRoomData {
   capacity: number;
 }
 
+// 스터디룸 상세 정보
+export interface StudyRoomDetailData {
+  studyRoomId: number;
+  workplaceId: number;
+  workplaceName: string;
+  studyRoomName: string;
+  description: string;
+  imageUrl: string[];
+  price: number;
+  capacity: number;
+}
+
 // 스터디룸 검색
 export interface SearchStudyRoom {
   workplaceAddress: string;

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -146,6 +146,14 @@ export interface StudyRoomDetailData {
   capacity: number;
 }
 
+// 스터디룸의 예약 가능한 시간대
+export interface PossibleTime {
+  capacity: number;
+  possibleTime: string[];
+  startTime: string;
+  endTime: string;
+}
+
 // 스터디룸 검색
 export interface SearchStudyRoom {
   workplaceAddress: string;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 스터디룸 상세 정보 페이지 구현 완료
- 예약 및 결제 페이지, 결제 완료 페이지 개선

## 📝 요구 사항과 구현 내용
- 스터디룸 상세 정보에서 가격 & 인원 안내 추가
- 예약 가능한 시간대 조회 api 연동
- 날짜 선택 시 불가능한 시간대는 선택 못하도록 처리 및 스타일 적용
-  시간, 인원 미선택 시 예약 페이지로 못넘어가도록 설정
- 예약 페이지로 넘어갈 때 스터디룸 정보 전달
- 환불 규정 문구 수정

## ✅ 피드백 반영사항
- 환불 규정 잘못 적은거 또 잊고 있다가 아까 현진님 PR 보고 호다닥 수정했습니다 ,,,,ㅎㅎㅎㅎ

## 💬 PR 포인트 & 궁금한 점
- 이게 스터디룸 상세 정보 -> 예약 -> 결제로 넘어가다 보니까 연관된 곳이 많아서 수정된 파일 수가 꽤 많아졌어요 .. 

## 🔗 연관된 이슈
- close #39 
- close #46 
- 이슈 두개나 닫는다 happy ... :)