### PR TITLE
✨ Feat : 리뷰 작성 및 조회, 하단 네비게이션 바 기능 구현 완료

### DIFF
--- a/src/apis/reservation.ts
+++ b/src/apis/reservation.ts
@@ -7,6 +7,7 @@ import {
   PostPaymentsData,
   PostReservationData,
   Reservation,
+  ReserverInfo,
 } from '@typings/types';
 import { authInstance } from '.';
 
@@ -35,6 +36,10 @@ export const getLatestReservation = async (): Promise<Reservation> => {
 };
 
 // 사업자의 예약자 조회
+export const getAllReserver = async (): Promise<ReserverInfo> => {
+  const response = await authInstance.get('/api/v1/reservations/all/workplace');
+  return response.data;
+};
 
 // 결제 검증
 export const postPaymentsToss = async (

--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -37,7 +37,7 @@ export const getNextPage = async (
 
 // 내가 작성한 리뷰 조회 - 로그인
 export const getMyReview = async (): Promise<Review[]> => {
-  const response = await authInstance.get('/api/vi/review/me');
+  const response = await authInstance.get('/api/v1/review/me');
   return response.data;
 };
 

--- a/src/layouts/BottomNavigation.tsx
+++ b/src/layouts/BottomNavigation.tsx
@@ -2,29 +2,50 @@ import { AiFillHome } from 'react-icons/ai';
 import { BsChatDots } from 'react-icons/bs';
 import { CgSearch } from 'react-icons/cg';
 import { BiUser } from 'react-icons/bi';
-import { useState } from 'react';
+import useAuthStore from '@store/authStore';
+import { getRole } from '@utils/auth';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 const BottomNavigation = () => {
-  const [activeTab, setActiveTab] = useState('홈');
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { isLogin } = useAuthStore();
+  const role = getRole();
+  const myPagePath = role === 'ROLE_USER' ? '/user-page' : '/host-page';
+
   const navigationItems = [
-    { icon: <AiFillHome />, label: '홈' },
-    { icon: <BsChatDots />, label: '문의' },
-    { icon: <CgSearch />, label: '검색' },
-    { icon: <BiUser />, label: '마이페이지' },
+    { icon: <AiFillHome />, label: '홈', path: '/' },
+    { icon: <BsChatDots />, label: '문의', path: isLogin ? '/chat-list' : '/' },
+    { icon: <CgSearch />, label: '검색', path: '/search' },
+    { icon: <BiUser />, label: '마이페이지', path: isLogin ? myPagePath : '/' },
   ];
+
+  // 현재 경로를 기준으로 활성화된 탭 설정
+  const activeTab =
+    navigationItems.find((item) => item.path === location.pathname)?.label ||
+    '홈';
+
+  const handleMovePage = (path: string) => {
+    if (!isLogin && (path === '/chat-list' || path === myPagePath)) {
+      navigate(path);
+      toast.error('로그인 후 이용해주세요');
+      return;
+    }
+    navigate(path);
+  };
 
   return (
     <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>
-      {navigationItems.map(({ icon, label }) => (
+      {navigationItems.map(({ icon, label, path }) => (
         <button
           type='button'
           key={label}
           className={`flex w-[45px] cursor-pointer flex-col items-center ${
             activeTab === label ? 'text-primary' : 'text-focusColor'
           }`}
-          onClick={() => {
-            setActiveTab(label);
-          }}
+          onClick={() => handleMovePage(path)}
         >
           <div className='text-[20px]'>{icon}</div>
           <p className='mt-1 text-[10px]'>{label}</p>

--- a/src/layouts/BottomNavigation.tsx
+++ b/src/layouts/BottomNavigation.tsx
@@ -5,7 +5,6 @@ import { BiUser } from 'react-icons/bi';
 import useAuthStore from '@store/authStore';
 import { getRole } from '@utils/auth';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
 
 const BottomNavigation = () => {
   const navigate = useNavigate();
@@ -17,9 +16,17 @@ const BottomNavigation = () => {
 
   const navigationItems = [
     { icon: <AiFillHome />, label: '홈', path: '/' },
-    { icon: <BsChatDots />, label: '문의', path: isLogin ? '/chat-list' : '/' },
+    {
+      icon: <BsChatDots />,
+      label: '문의',
+      path: isLogin ? '/chat-list' : '/start',
+    },
     { icon: <CgSearch />, label: '검색', path: '/search' },
-    { icon: <BiUser />, label: '마이페이지', path: isLogin ? myPagePath : '/' },
+    {
+      icon: <BiUser />,
+      label: '마이페이지',
+      path: isLogin ? myPagePath : '/start',
+    },
   ];
 
   // 현재 경로를 기준으로 활성화된 탭 설정
@@ -30,7 +37,6 @@ const BottomNavigation = () => {
   const handleMovePage = (path: string) => {
     if (!isLogin && (path === '/chat-list' || path === myPagePath)) {
       navigate(path);
-      toast.error('로그인 후 이용해주세요');
       return;
     }
     navigate(path);

--- a/src/pages/ManagementReserverPage/hooks/useGetReserver.ts
+++ b/src/pages/ManagementReserverPage/hooks/useGetReserver.ts
@@ -1,0 +1,12 @@
+import { getAllReserver } from '@apis/reservation';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetReserver = () => {
+  const { data } = useQuery({
+    queryKey: ['reserver'],
+    queryFn: () => getAllReserver(),
+  });
+  return { reserver: data ?? [] };
+};
+
+export default useGetReserver;

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -149,7 +149,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
         {modalOpen && (
           <Modal
             message='결제를 취소하시겠습니까?'
-            cancelPaymentMessage={`${cancelPaymentText}`}
+            cancelPaymentMessage={cancelPaymentText}
             onCancelButtonClick={() => setModalOpen(false)}
             onConfirmButtonClick={handleCancelPayment}
           />

--- a/src/pages/ReviewListPage/components/MyReviewCard.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewCard.tsx
@@ -2,14 +2,17 @@ import { MdArrowForwardIos } from 'react-icons/md';
 import { FaStar, FaRegStar } from 'react-icons/fa6';
 import { getDateFunction } from '@utils/formatTime';
 import { Review } from '@typings/types';
+import { Link } from 'react-router-dom';
 
 const MyReviewCard = ({ item }: { item: Review }) => {
   const {
-    workPlaceName,
+    workplaceName,
+    workplaceId,
+    studyRoomName,
     reviewContent,
     reviewRating,
-    studyRoomName,
     reviewDate,
+    workplaceImageURL,
   } = item;
 
   const showRatingWithStar = (rating: number) => {
@@ -27,11 +30,11 @@ const MyReviewCard = ({ item }: { item: Review }) => {
     <div className='mx-auto flex w-custom flex-col gap-[13px] border-b border-solid border-b-black px-[13px] py-[26px]'>
       <div className='flex items-start justify-between'>
         <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-          {workPlaceName}
+          <Link to={`/detail/${workplaceId}`}>{workplaceName}</Link>
           <MdArrowForwardIos className='w-3' />
         </div>
         <img
-          src='사진'
+          src={workplaceImageURL}
           alt='스터디룸 사진'
           className='h-[50px] w-[50px] cursor-pointer object-cover'
         />

--- a/src/pages/ReviewListPage/components/MyReviewCard.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewCard.tsx
@@ -4,7 +4,13 @@ import { getDateFunction } from '@utils/formatTime';
 import { Review } from '@typings/types';
 
 const MyReviewCard = ({ item }: { item: Review }) => {
-  const { reviewContent, reviewRating, studyRoomName, reviewDate } = item;
+  const {
+    workPlaceName,
+    reviewContent,
+    reviewRating,
+    studyRoomName,
+    reviewDate,
+  } = item;
 
   const showRatingWithStar = (rating: number) => {
     const result = [];
@@ -21,8 +27,7 @@ const MyReviewCard = ({ item }: { item: Review }) => {
     <div className='mx-auto flex w-custom flex-col gap-[13px] border-b border-solid border-b-black px-[13px] py-[26px]'>
       <div className='flex items-start justify-between'>
         <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-          {/* {workplaceName} */}
-          사업장 이름
+          {workPlaceName}
           <MdArrowForwardIos className='w-3' />
         </div>
         <img

--- a/src/pages/ReviewListPage/components/MyReviewList.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewList.tsx
@@ -13,7 +13,7 @@ const MyReviewList = () => {
   return (
     <>
       {myReviewList && myReviewList.length > 0 ? (
-        <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
+        <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
           {sortedReviewList.map((item) => {
             return (
               <MyReviewCard

--- a/src/pages/ReviewListPage/components/MyReviewList.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewList.tsx
@@ -6,7 +6,7 @@ const MyReviewList = () => {
 
   const sortedReviewList = myReviewList
     ? [...myReviewList].sort((b, a) => {
-        return +a.reviewDate - +b.reviewDate;
+        return +new Date(a.reviewDate) - +new Date(b.reviewDate);
       })
     : [];
 

--- a/src/pages/ReviewListPage/components/MyReviewList.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewList.tsx
@@ -2,7 +2,7 @@ import useGetMyReviewList from '../hooks/useGetMyReviewList';
 import MyReviewCard from './MyReviewCard';
 
 const MyReviewList = () => {
-  const { data: myReviewList } = useGetMyReviewList();
+  const { myReviewList } = useGetMyReviewList();
 
   const sortedReviewList = myReviewList
     ? [...myReviewList].sort((b, a) => {

--- a/src/pages/ReviewListPage/hooks/useGetMyReviewList.ts
+++ b/src/pages/ReviewListPage/hooks/useGetMyReviewList.ts
@@ -1,12 +1,13 @@
 import { getMyReview } from '@apis/review';
 import { useQuery } from '@tanstack/react-query';
+import { Review } from '@typings/types';
 
 const useGetMyReviewList = () => {
   const { data } = useQuery({
     queryKey: ['myReview'],
     queryFn: () => getMyReview(),
   });
-  return { data };
+  return { myReviewList: (data ?? []) as Review[] };
 };
 
 export default useGetMyReviewList;

--- a/src/pages/UserMypage/components/LatestReservation.tsx
+++ b/src/pages/UserMypage/components/LatestReservation.tsx
@@ -17,7 +17,7 @@ const LatestReservation = ({ data }: { data: Reservation }) => {
   return (
     <>
       <Link to='/reservation-list'>
-        <div className='flex h-auto min-h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-[0_0_6px_0_rgba(0,0,0,0.25)]'>
+        <div className='flex h-auto min-h-[172px] w-[330px] flex-col rounded-[10px] bg-white p-[16px] shadow-custom'>
           <div className='flex justify-start gap-[13px]'>
             <img
               src={workplaceImageUrl}

--- a/src/pages/WriteReviewPage/components/WriteReview.tsx
+++ b/src/pages/WriteReviewPage/components/WriteReview.tsx
@@ -53,7 +53,6 @@ const WriteReview = ({
 
   const submitHandler = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(postData);
     writeReview(postData);
   };
 

--- a/src/pages/WriteReviewPage/hooks/usePostReview.ts
+++ b/src/pages/WriteReviewPage/hooks/usePostReview.ts
@@ -9,8 +9,7 @@ const usePostReview = () => {
 
   const writeReview = useMutation({
     mutationFn: (data: PostReviewRequestBody) => postReview(data),
-    onSuccess: (data) => {
-      console.log(data, '리뷰 작성 성공');
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myReview'] });
       navigate('/review-list');
     },

--- a/src/pages/WriteReviewPage/index.tsx
+++ b/src/pages/WriteReviewPage/index.tsx
@@ -19,6 +19,7 @@ const WriteReviewPage = () => {
   const location = useLocation();
   const reservationInfo: WriteReviewProps = { ...location.state };
   const { reservationId, workPlaceName } = reservationInfo;
+  console.log(reservationId);
 
   return (
     <MainLayout>

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -119,7 +119,7 @@ export interface PostReviewRequestBody extends PutReviewRequestBody {
 // 내가 작성한 리뷰 정보
 export interface Review {
   reviewId: number;
-  workPlaceName: string;
+  workplaceName: string;
   workplaceId: number;
   studyRoomName: string;
   reviewContent: string;

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -125,7 +125,7 @@ export interface Review {
   reviewContent: string;
   reviewRating: number;
   reviewDate: string;
-  // workplace img url: string;
+  workplaceImageURL: string;
 }
 
 // 스터디룸 등록

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -116,11 +116,14 @@ export interface PostReviewRequestBody extends PutReviewRequestBody {
   workPlaceName: string;
 }
 
-// 리뷰 정보
-export interface Review extends PostReviewRequestBody {
+// 내가 작성한 리뷰 정보
+export interface Review {
   reviewId: number;
+  workPlaceName: string;
   workplaceId: number;
   studyRoomName: string;
+  reviewContent: string;
+  reviewRating: number;
   reviewDate: string;
   // workplace img url: string;
 }

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -90,6 +90,19 @@ export interface Reservation {
   price: number;
 }
 
+// 사업자의 예약자 확인
+export interface ReserverInfo {
+  workplaceName: string;
+  reservationName: string;
+  reservationPhoneNumber: string;
+  studyRoomName: string;
+  reservationCreatedAt: string;
+  reservationStartTime: string;
+  reservationEndTime: string;
+  reservationCapacity: number;
+  price: number;
+}
+
 // 리뷰 수정
 export interface PutReviewRequestBody {
   reviewContent: string;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 리뷰 작성 및 조회, 하단 네비게이션 바 기능 구현 완료

## 📝 요구 사항과 구현 내용
- 리뷰 작성 기능 구현 완료
- 내가 작성한 리뷰 조회 구현 완료
- 하단 네비게이션 바 연결 완료
  - 로그인한 사용자가 아니면 /start 페이지로 이동
  - 로그인 한 상태에서 사용자 / 사업자인지에 따라 마이페이지 다르게 연결
 

## ✅ 피드백 반영사항
- cancelPaymentText 수정 완료
  ```
  cancelPaymentMessage={cancelPaymentText}
  ```
- shadow-custom 사용

## 💬 PR 포인트 & 궁금한 점
지금 마이페이지에서 
<img width="361" alt="image" src="https://github.com/user-attachments/assets/cb91f913-5344-4047-87eb-5514db3ee1c9">

  이런 카드가 있으면 제목을 눌렀을 때만 상세페이지로 이동하도록 구현했는데, 사진을 클릭해도 상세페이지로 이동하게 하는 게 좋을까요?

## 🔗 연관된 이슈
- close #15 
- close #25 
- close #97 