### PR TITLE
✨ Feat : 사업자 예약자 조회, 리뷰 작성 완료된 예약 문구 표시 및 리뷰 페이지로 이동

### DIFF
--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -74,7 +74,7 @@ const ManagementPlaceCard = ({ item }: ManagementPlaceCardProps) => {
           <img
             src={imageUrl}
             alt='스터디룸 사진'
-            className='h-[50px] w-[50px] cursor-pointer object-cover'
+            className='h-[50px] w-[50px] object-cover'
           />
         </div>
 

--- a/src/pages/ManagementReserverPage/components/ReserverCard.tsx
+++ b/src/pages/ManagementReserverPage/components/ReserverCard.tsx
@@ -64,7 +64,7 @@ const ReserverCard = ({ item }: { item: ReserverInfo }) => {
           <img
             src={workplaceImageUrl}
             alt='스터디룸 사진'
-            className='h-[50px] w-[50px] cursor-pointer object-cover'
+            className='h-[50px] w-[50px] object-cover'
           />
           <span className='self-end text-sm font-normal'>
             {reservationPrice.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}{' '}

--- a/src/pages/ManagementReserverPage/components/ReserverCard.tsx
+++ b/src/pages/ManagementReserverPage/components/ReserverCard.tsx
@@ -1,20 +1,22 @@
 import { MdArrowForwardIos } from 'react-icons/md';
 import { getDateFunction, getTimeFunction } from '@utils/formatTime';
 import ListStyle from '@components/ListStyle';
-import { ReserverInfo } from './ReserverList';
+import { ReserverInfo } from '@typings/types';
+import { Link } from 'react-router-dom';
 
 const ReserverCard = ({ item }: { item: ReserverInfo }) => {
   const {
-    studyroomTitle,
-    roomTitle,
+    workplaceName,
     reservationName,
-    reservationPhonenumber,
-    startTime,
-    endTime,
-    price,
-    studyroomImage,
-    createdAt,
-    numberOfReserver,
+    reservationPhoneNumber,
+    studyRoomName,
+    reservationCreatedAt,
+    reservationStartTime,
+    reservationEndTime,
+    reservationCapacity,
+    workplaceImageUrl,
+    workplaceId,
+    reservationPrice,
   } = item;
 
   return (
@@ -22,7 +24,7 @@ const ReserverCard = ({ item }: { item: ReserverInfo }) => {
       <div className='flex justify-between'>
         <div className='flex flex-col items-start gap-4'>
           <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-            {studyroomTitle}
+            <Link to={`/detail/${workplaceId}`}>{workplaceName}</Link>
             <MdArrowForwardIos className='w-3' />
           </div>
 
@@ -33,39 +35,40 @@ const ReserverCard = ({ item }: { item: ReserverInfo }) => {
             />
             <ListStyle
               name='전화번호'
-              value={reservationPhonenumber}
+              value={reservationPhoneNumber}
             />
             <ListStyle
               name='예약된 룸'
-              value={roomTitle}
+              value={studyRoomName}
             />
             <ListStyle
               name='예약일'
-              value={getDateFunction(startTime)}
+              value={getDateFunction(reservationStartTime)}
             />
             <ListStyle
               name='예약 시간'
-              value={`${getTimeFunction(startTime)} ~ ${getTimeFunction(endTime)}`}
+              value={`${getTimeFunction(reservationStartTime)} ~ ${getTimeFunction(reservationEndTime)}`}
             />
             <ListStyle
               name='인원'
-              value={`${numberOfReserver}인`}
+              value={`${reservationCapacity}인`}
             />
             <ListStyle
               name='결제일'
-              value={getDateFunction(createdAt)}
+              value={getDateFunction(reservationCreatedAt)}
             />
           </ul>
         </div>
 
         <div className='flex flex-col justify-between'>
           <img
-            src={studyroomImage}
+            src={workplaceImageUrl}
             alt='스터디룸 사진'
             className='h-[50px] w-[50px] cursor-pointer object-cover'
           />
           <span className='self-end text-sm font-normal'>
-            {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원
+            {reservationPrice.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}{' '}
+            원
           </span>
         </div>
       </div>

--- a/src/pages/ManagementReserverPage/components/ReserverList.tsx
+++ b/src/pages/ManagementReserverPage/components/ReserverList.tsx
@@ -1,49 +1,23 @@
+import useGetReserver from '../hooks/useGetReserver';
 import ReserverCard from './ReserverCard';
 
-export interface ReserverInfo {
-  revervationId: number;
-  studyroomTitle: string;
-  roomTitle: string;
-  reservationName: string;
-  reservationPhonenumber: string;
-  startTime: string;
-  endTime: string;
-  price: number;
-  numberOfReserver: number;
-  studyroomImage: string;
-  createdAt: string;
-}
-
-const reserverList: ReserverInfo[] = [
-  {
-    revervationId: 1,
-    studyroomTitle: 'ABC 스터디룸',
-    roomTitle: 'ROOM A',
-    reservationName: '홍길동',
-    reservationPhonenumber: '010-1111-1111',
-    startTime: '2024-11-21T09:00:00',
-    endTime: '2024-11-21T16:00:00',
-    price: 8000,
-    numberOfReserver: 4,
-    studyroomImage:
-      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230323_120%2F1679571970387BaDBd_JPEG%2F1679570041991-0.jpg',
-    createdAt: '2024-11-16T06:42:12',
-  },
-];
-
 const ReserverList = () => {
+  const { reserverList } = useGetReserver();
+
   const sortedReserverList = [...reserverList].sort((b, a) => {
-    return +new Date(b.createdAt) - +new Date(a.createdAt);
+    return (
+      +new Date(a.reservationCreatedAt) - +new Date(b.reservationCreatedAt)
+    );
   });
 
   return (
     <>
       {reserverList.length > 0 ? (
-        <div className='mt-[6px] flex w-[375px] flex-col justify-center'>
+        <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
           {sortedReserverList.map((item) => {
             return (
               <ReserverCard
-                key={item.revervationId}
+                key={item.reservationId}
                 item={item}
               />
             );

--- a/src/pages/ManagementReserverPage/hooks/useGetReserver.ts
+++ b/src/pages/ManagementReserverPage/hooks/useGetReserver.ts
@@ -1,12 +1,13 @@
 import { getAllReserver } from '@apis/reservation';
 import { useQuery } from '@tanstack/react-query';
+import { ReserverInfo } from '@typings/types';
 
 const useGetReserver = () => {
   const { data } = useQuery({
     queryKey: ['reserver'],
     queryFn: () => getAllReserver(),
   });
-  return { reserver: data ?? [] };
+  return { reserverList: (data ?? []) as ReserverInfo[] };
 };
 
 export default useGetReserver;

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import Modal from '@components/Modal';
 import { Reservation } from '@typings/types';
 import { MdArrowForwardIos } from 'react-icons/md';
+import { FaArrowRight } from 'react-icons/fa6';
 import useCancelPayment from '../hooks/useCancelPayment';
 
 interface CancelPaymentText {
@@ -25,6 +26,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
     workplaceImageUrl,
     studyRoomName,
     reservationId,
+    existReview,
   } = item;
   const navigate = useNavigate();
   const { mutate: cancelPayment } = useCancelPayment();
@@ -131,11 +133,20 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
               onClickFunction={() => setModalOpen(true)}
             />
           )}
-          {buttonText === 'review' && (
+          {buttonText === 'review' && !existReview ? (
             <ButtonInCard
               name='리뷰 작성'
               onClickFunction={handleReviewButton}
             />
+          ) : (
+            <Link to='/review-list'>
+              <div className='flex h-[34px] items-end justify-end text-[12px] text-subfont active:text-focusColor'>
+                <span className='flex items-center gap-1'>
+                  리뷰 작성이 완료된 예약입니다
+                  <FaArrowRight />
+                </span>
+              </div>
+            </Link>
           )}
           {buttonText === 'none' && (
             <span className='flex h-[34px] flex-col justify-end text-[12px] text-primary'>

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -127,18 +127,7 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
           </div>
         </div>
         <div className='flex items-end justify-between'>
-          {buttonText === 'cancelPayment' && (
-            <ButtonInCard
-              name='결제 취소'
-              onClickFunction={() => setModalOpen(true)}
-            />
-          )}
-          {buttonText === 'review' && !existReview ? (
-            <ButtonInCard
-              name='리뷰 작성'
-              onClickFunction={handleReviewButton}
-            />
-          ) : (
+          {existReview ? (
             <Link to='/review-list'>
               <div className='flex h-[34px] items-end justify-end text-[12px] text-subfont active:text-focusColor'>
                 <span className='flex items-center gap-1'>
@@ -147,11 +136,26 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
                 </span>
               </div>
             </Link>
-          )}
-          {buttonText === 'none' && (
-            <span className='flex h-[34px] flex-col justify-end text-[12px] text-primary'>
-              방문 24시간 전입니다.
-            </span>
+          ) : (
+            <>
+              {buttonText === 'cancelPayment' && (
+                <ButtonInCard
+                  name='결제 취소'
+                  onClickFunction={() => setModalOpen(true)}
+                />
+              )}
+              {buttonText === 'review' && (
+                <ButtonInCard
+                  name='리뷰 작성'
+                  onClickFunction={handleReviewButton}
+                />
+              )}
+              {buttonText === 'none' && (
+                <span className='flex h-[34px] flex-col justify-end text-[12px] text-primary'>
+                  방문 24시간 전입니다.
+                </span>
+              )}
+            </>
           )}
           <span className='text-[14px] font-normal'>
             {price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원

--- a/src/pages/ReviewListPage/components/MyReviewCard.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewCard.tsx
@@ -36,7 +36,7 @@ const MyReviewCard = ({ item }: { item: Review }) => {
         <img
           src={workplaceImageURL}
           alt='스터디룸 사진'
-          className='h-[50px] w-[50px] cursor-pointer object-cover'
+          className='h-[50px] w-[50px] object-cover'
         />
       </div>
 

--- a/src/pages/WriteReviewPage/hooks/usePostReview.ts
+++ b/src/pages/WriteReviewPage/hooks/usePostReview.ts
@@ -10,7 +10,9 @@ const usePostReview = () => {
   const writeReview = useMutation({
     mutationFn: (data: PostReviewRequestBody) => postReview(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myReview'] });
+      queryClient.invalidateQueries({
+        queryKey: ['myReview', 'myReservationList'],
+      });
       navigate('/review-list');
     },
   });

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -89,6 +89,7 @@ export interface Reservation {
   endTime: string;
   reservationCapacity: number;
   price: number;
+  existReview: boolean;
 }
 
 // 사업자의 예약자 확인
@@ -101,7 +102,10 @@ export interface ReserverInfo {
   reservationStartTime: string;
   reservationEndTime: string;
   reservationCapacity: number;
-  price: number;
+  workplaceImageUrl: string;
+  workplaceId: number;
+  reservationId: string;
+  reservationPrice: number;
 }
 
 // 리뷰 수정


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업자 예약자 조회
- 리뷰 작성 완료된 예약 문구 표시 및 리뷰 페이지로 이동

## 📝 요구 사항과 구현 내용
- 사업자 예약자 조회 api 연결
- 사용자 예약 정보 조회 타입, 사업자의 예약자 조회 타입 수정
- 리뷰 작성 완료된 예약 문구 표시
- 리뷰 작성 완료된 예약 문구 누르면 리뷰 페이지로 이동

## ✅ 피드백
- 사용자/사업자 마이페이지쪽에서 사진을 눌러도 상세페이지로 이동하지 않도록 하기로 결정 -> img태그 cursor-pointer 삭제

## 💬 PR 포인트 
- 마이페이지쪽 예약이나 사업장 데이터가 없으면 에러가 뜨는 문제가 아직 남아있습니다! 백엔드쪽 업데이트 후 제대로 뜨는지 확인이 필요합니다
- 예약 내역 페이지에서 결제 취소 api쪽을 다시 확인해봐야할 것 같습니다ㅠ

## 🔧 버그 해결
- 리뷰 작성 완료 문구 동시에 보이는 버그 해결했습니다..!

## 🔗 연관된 이슈
- close #31
- close #6 
- close #9 

PR포인트에서 언급한 문제 확인 다시 해봐야겠지만 이슈는 닫아놓겠습니닿~!