### PR TITLE
✨ Feat : 사업장 삭제 시 s3 사업장 사진 폴더도 삭제, 헤더 라우터 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/uuid": "^10.0.0",
         "axios": "^1.7.7",
         "buffer": "^6.0.3",
+        "eventsource": "^2.0.2",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/uuid": "^10.0.0",
     "axios": "^1.7.7",
     "buffer": "^6.0.3",
+    "eventsource": "^2.0.2",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "react": "^18.3.1",

--- a/src/apis/business.ts
+++ b/src/apis/business.ts
@@ -9,7 +9,7 @@ export const getBusinessData = async (): Promise<Business> => {
 
 // 사업자 알림
 export const getBusinessAlarm = async (): Promise<BusinessAlarm> => {
-  const response = await authInstance.get('/api/v1/business/notification');
+  const response = await authInstance.get('/api/v1/notification/business');
   return response.data;
 };
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -45,7 +45,7 @@ authInstance.interceptors.response.use(
       try {
         const response = await authInstance.post('/reissue');
 
-        if (response.status === 200) {
+        if (response.status === 202) {
           const token = response.headers.authorization;
           setAuthToken(token);
 

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -9,7 +9,7 @@ export const getUserData = async (): Promise<Member> => {
 
 // 유저 알림
 export const getUserAlarm = async (): Promise<Alarm> => {
-  const response = await authInstance.get('/api/v1/member/notification');
+  const response = await authInstance.get('/api/v1/notification/member');
   return response.data;
 };
 

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -110,6 +110,15 @@ export const deleteWorkPlace = async (workplaceId: number): Promise<void> => {
   return response.data;
 };
 
+// 사업장 삭제 시 이미지 삭제
+export const deleteWorkPlaceImage = async (
+  fileLocation: string,
+): Promise<void> => {
+  await authInstance.delete(`/api/delete-folder`, {
+    params: { fileLocation },
+  });
+};
+
 // 사업장 정보 조회
 export const getWorkPlace = async (
   workplaceId: number,

--- a/src/components/ListStyle.tsx
+++ b/src/components/ListStyle.tsx
@@ -6,8 +6,8 @@ interface ListProps {
 const ListStyle = ({ name, value }: ListProps) => {
   return (
     <li className='flex gap-[12px]'>
-      <p className='w-[48px]'>{name}</p>
-      <span className='w-auto break-keep font-normal'>{value}</span>
+      <p className='w-[48px] flex-shrink-0'>{name}</p>
+      <span className='flex-grow break-keep font-normal'>{value}</span>
     </li>
   );
 };

--- a/src/components/LogoAndNotification.tsx
+++ b/src/components/LogoAndNotification.tsx
@@ -1,0 +1,20 @@
+import Logo from '@assets/images/roomit_logo.png';
+import { RiNotification3Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
+
+const LogoAndNotification = () => {
+  return (
+    <>
+      <Link to='/'>
+        <img
+          className='h-[15px] w-[50px]'
+          src={Logo}
+          alt='ROOM:IT 로고'
+        />
+      </Link>
+      <RiNotification3Line className='h-[24px] w-[24px]' />
+    </>
+  );
+};
+
+export default LogoAndNotification;

--- a/src/components/LogoAndNotification.tsx
+++ b/src/components/LogoAndNotification.tsx
@@ -1,6 +1,7 @@
 import Logo from '@assets/images/roomit_logo.png';
 import useAuthStore from '@store/authStore';
 import { getRole } from '@utils/auth';
+
 import { RiNotification3Line } from 'react-icons/ri';
 import { Link, useNavigate } from 'react-router-dom';
 

--- a/src/components/LogoAndNotification.tsx
+++ b/src/components/LogoAndNotification.tsx
@@ -1,8 +1,22 @@
 import Logo from '@assets/images/roomit_logo.png';
+import useAuthStore from '@store/authStore';
+import { getRole } from '@utils/auth';
 import { RiNotification3Line } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const LogoAndNotification = () => {
+  const navigate = useNavigate();
+  const { isLogin } = useAuthStore();
+  const role = getRole();
+
+  const handleMoveToNotiPageClick = () => {
+    if (role === 'ROLE_USER') {
+      navigate('/user-noti');
+    } else {
+      navigate('/host-noti');
+    }
+  };
+
   return (
     <>
       <Link to='/'>
@@ -12,7 +26,12 @@ const LogoAndNotification = () => {
           alt='ROOM:IT 로고'
         />
       </Link>
-      <RiNotification3Line className='h-[24px] w-[24px]' />
+      {isLogin && (
+        <RiNotification3Line
+          className='h-[24px] w-[24px] cursor-pointer'
+          onClick={handleMoveToNotiPageClick}
+        />
+      )}
     </>
   );
 };

--- a/src/components/notiContainer.tsx
+++ b/src/components/notiContainer.tsx
@@ -1,0 +1,5 @@
+const notiContainer = (message: string) => {
+  return <div className='h-[50px] w-custom bg-primary'>{message}</div>;
+};
+
+export default notiContainer;

--- a/src/layouts/HeaderNoTitle.tsx
+++ b/src/layouts/HeaderNoTitle.tsx
@@ -1,19 +1,10 @@
-import Logo from '@assets/images/roomit_logo.png';
-import { RiNotification3Line } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import LogoAndNotification from '@components/LogoAndNotification';
 
 const HeaderNoTitle = () => {
   return (
     <div className='fixed top-0 z-[1000] flex h-[93px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] flex h-[37px] w-[330px] items-center justify-between'>
-        <Link to='/'>
-          <img
-            className='h-[15px] w-[50px]'
-            src={Logo}
-            alt='ROOM:IT 로고'
-          />
-        </Link>
-        <RiNotification3Line className='h-[24px] w-[24px]' />
+        <LogoAndNotification />
       </div>
     </div>
   );

--- a/src/layouts/HeaderNoTitle.tsx
+++ b/src/layouts/HeaderNoTitle.tsx
@@ -1,15 +1,18 @@
 import Logo from '@assets/images/roomit_logo.png';
 import { RiNotification3Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 
 const HeaderNoTitle = () => {
   return (
     <div className='fixed top-0 z-[1000] flex h-[93px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] flex h-[37px] w-[330px] items-center justify-between'>
-        <img
-          className='h-[15px] w-[50px]'
-          src={Logo}
-          alt='ROOM:IT 로고'
-        />
+        <Link to='/'>
+          <img
+            className='h-[15px] w-[50px]'
+            src={Logo}
+            alt='ROOM:IT 로고'
+          />
+        </Link>
         <RiNotification3Line className='h-[24px] w-[24px]' />
       </div>
     </div>

--- a/src/layouts/HeaderWithTitle.tsx
+++ b/src/layouts/HeaderWithTitle.tsx
@@ -1,6 +1,4 @@
-import Logo from '@assets/images/roomit_logo.png';
-import { RiNotification3Line } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import LogoAndNotification from '@components/LogoAndNotification';
 
 export interface TitleProps {
   title: string;
@@ -11,14 +9,7 @@ const HeaderWithTitle = ({ title }: TitleProps) => {
     <div className='fixed top-0 z-[1000] flex h-[132px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] w-[330px] flex-col'>
         <div className='flex h-[37px] w-[100%] items-center justify-between'>
-          <Link to='/'>
-            <img
-              className='h-[15px] w-[50px]'
-              src={Logo}
-              alt='ROOM:IT 로고'
-            />
-          </Link>
-          <RiNotification3Line className='h-[24px] w-[24px]' />
+          <LogoAndNotification />
         </div>
         <p className='flex h-[42px] w-[100%] items-center justify-center text-[18px] font-normal'>
           {title}

--- a/src/layouts/HeaderWithTitle.tsx
+++ b/src/layouts/HeaderWithTitle.tsx
@@ -1,5 +1,6 @@
 import Logo from '@assets/images/roomit_logo.png';
 import { RiNotification3Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 
 export interface TitleProps {
   title: string;
@@ -10,11 +11,13 @@ const HeaderWithTitle = ({ title }: TitleProps) => {
     <div className='fixed top-0 z-[1000] flex h-[132px] w-[375px] flex-col items-center bg-white'>
       <div className='fixed top-[46px] w-[330px] flex-col'>
         <div className='flex h-[37px] w-[100%] items-center justify-between'>
-          <img
-            className='h-[15px] w-[50px]'
-            src={Logo}
-            alt='ROOM:IT 로고'
-          />
+          <Link to='/'>
+            <img
+              className='h-[15px] w-[50px]'
+              src={Logo}
+              alt='ROOM:IT 로고'
+            />
+          </Link>
           <RiNotification3Line className='h-[24px] w-[24px]' />
         </div>
         <p className='flex h-[42px] w-[100%] items-center justify-center text-[18px] font-normal'>

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -27,11 +27,14 @@ const ManagementPlaceCard = ({ item }: ManagementPlaceCardProps) => {
   const [modalOpen, setModalOpen] = useState(false);
 
   const numberOfRooms = useGetNumberOfRooms(workplaceId);
-  const { mutate: deleteMutation } = useDeleteBusinessPlace(workplaceId);
+  const { mutate: deleteMutation } = useDeleteBusinessPlace();
 
   // 사업장 삭제
   const handleDeleteBusinessWorkplace = () => {
-    deleteMutation();
+    deleteMutation({
+      workPlaceId: workplaceId,
+      fileLocation: `workplace-${workplaceId}`,
+    });
     setModalOpen(() => false);
   };
 

--- a/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
+++ b/src/pages/ManagementPlacePage/components/ManagementPlaceCard.tsx
@@ -74,7 +74,7 @@ const ManagementPlaceCard = ({ item }: ManagementPlaceCardProps) => {
           <img
             src={imageUrl}
             alt='스터디룸 사진'
-            className='h-[50px] w-[50px] object-cover'
+            className='ml-3 h-[50px] w-[50px] object-cover'
           />
         </div>
 

--- a/src/pages/ManagementPlacePage/hooks/useDeleteBusinessPlace.ts
+++ b/src/pages/ManagementPlacePage/hooks/useDeleteBusinessPlace.ts
@@ -1,11 +1,22 @@
-import { deleteWorkPlace } from '@apis/workplace';
+import { deleteWorkPlace, deleteWorkPlaceImage } from '@apis/workplace';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-const useDeleteBusinessPlace = (workplaceId: number) => {
+interface DeleteWorkplaceParams {
+  workPlaceId: number;
+  fileLocation: string;
+}
+
+const useDeleteBusinessPlace = () => {
   const queryClient = useQueryClient();
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteWorkPlace(workplaceId),
+    mutationFn: async ({
+      workPlaceId,
+      fileLocation,
+    }: DeleteWorkplaceParams): Promise<void> => {
+      await deleteWorkPlace(workPlaceId);
+      await deleteWorkPlaceImage(fileLocation);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['businessWorkplaces'] });
     },


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업장 삭제 시 s3 사업장 사진 폴더 삭제
- 헤더 라우터 연결

## 📝 요구 사항과 구현 내용
- 로그인 한 사용자가 아니면 알림 아이콘 안 보이도록 처리
- 헤더 로고 누르면 홈으로 이동, 알림 아이콘 누르면 사용자/사업자 여부에 따라 알림 페이지로 이동
- 사업장 사진 삭제 시 s3 사진 폴더 삭제하는 api 요청 추가
- 알림 api 수정
- 실시간 알림 위해서 eventsource install

----

받고 npm install 해주세요!