### PR TITLE
♻️ Refactor : 지도 및 검색, 상세페이지 개선

### DIFF
--- a/src/apis/chat.ts
+++ b/src/apis/chat.ts
@@ -19,6 +19,8 @@ export const getChatList = async (): Promise<ChatListResponse[]> => {
 export const postCreateChatRoom = async (
   workplaceId: number,
 ): Promise<number> => {
-  const response = await authInstance.post('/api/v1/chat/create', workplaceId);
+  const response = await authInstance.post('/api/v1/chat/create', {
+    workplaceId,
+  });
   return response.data;
 };

--- a/src/pages/ChatListPage/index.tsx
+++ b/src/pages/ChatListPage/index.tsx
@@ -6,16 +6,7 @@ import useGetChatList from './hooks/useGetChatList';
 
 const ChatListPage = () => {
   const { data } = useGetChatList();
-  console.log(data);
 
-  // const data = [
-  //   {
-  //     roomId: 1,
-  //     id: 1,
-  //     name: 'JohnDoe2',
-  //     updatedAt: '2024-12-02T12:30:00',
-  //   },
-  // ];
   return (
     <>
       <MainLayout headerType='both'>

--- a/src/pages/ChatPage/components/MessageContainer.tsx
+++ b/src/pages/ChatPage/components/MessageContainer.tsx
@@ -44,12 +44,12 @@ const MessageContainer = (props: MessageContainerProps) => {
             {dateMessages.map((message) =>
               message.sender === user ? (
                 <SendMessage
-                  key={message.messageId}
+                  key={message.timestamp}
                   message={message}
                 />
               ) : (
                 <ReceiveMessage
-                  key={message.messageId}
+                  key={message.timestamp}
                   message={message}
                 />
               ),

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -60,7 +60,7 @@ const ChatPage = () => {
       client.onConnect = () => {
         console.log('Connected');
 
-        client.subscribe(`/sub/chat/room/${roomId}`, (message: IMessage) => {
+        client.subscribe(`/sub/chat`, (message: IMessage) => {
           try {
             const newMessage = JSON.parse(message.body);
             setMessages((prevMessages) => [...prevMessages, newMessage]);

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -58,6 +58,7 @@ const ChatPage = () => {
       // 구독
       client.onConnect = () => {
         console.log('Connected');
+
         client.subscribe(`/sub/chat/room/${roomId}`, (message: IMessage) => {
           try {
             const newMessage = JSON.parse(message.body);
@@ -99,7 +100,6 @@ const ChatPage = () => {
         destination: '/pub/sendMessage',
         body: JSON.stringify(chatMessage),
       });
-      loadMessage();
       console.log(chatMessage);
       console.log(messages);
     }

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -52,6 +52,7 @@ const ChatPage = () => {
       const client = new Client({
         brokerURL: WS_URL,
         webSocketFactory: () => new SockJS(WS_URL),
+        debug: (str) => console.log(str),
         reconnectDelay: 5000, // 자동 재연결
       });
 

--- a/src/pages/DetailPage/components/DetailNavigation.tsx
+++ b/src/pages/DetailPage/components/DetailNavigation.tsx
@@ -5,17 +5,22 @@ import { useNavigate } from 'react-router-dom';
 interface DetailNavigationProps {
   workplaceId: number;
   isBtnDisabled: boolean;
+  selectedRoomId: number;
 }
 
 const DetailNavigation = ({
   workplaceId,
   isBtnDisabled,
+  selectedRoomId,
 }: DetailNavigationProps) => {
   const navigate = useNavigate();
   const handleClickChat = async () => {
     const roomId = await postCreateChatRoom(workplaceId);
-    console.log(roomId);
     navigate(`/chat/${roomId}`);
+  };
+
+  const handleSelectRoom = async () => {
+    navigate(`/reservation/${selectedRoomId}`);
   };
 
   return (
@@ -38,6 +43,7 @@ const DetailNavigation = ({
           type='button'
           className='ml-[8px] w-[222px] rounded-[8px] text-white'
           disabled={isBtnDisabled}
+          onClick={handleSelectRoom}
           style={{
             backgroundColor: isBtnDisabled === false ? '#50BEAD' : '#c3c3c3',
           }}

--- a/src/pages/DetailPage/components/RoomSelect.tsx
+++ b/src/pages/DetailPage/components/RoomSelect.tsx
@@ -1,22 +1,25 @@
 import RoomComponent from '@pages/RegisterSpace/components/RoomComponent';
-import { Dispatch, SetStateAction, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Dispatch, SetStateAction } from 'react';
 import useGetStudyroomOfWorkplace from '../hooks/useGetStudyroomOfWorkplace';
 
 interface RoomSelectProps {
   setIsBtnDisabled: Dispatch<SetStateAction<boolean>>;
   workplaceId: number;
+  selectedRoomId: number;
+  setSelectedRoomId: Dispatch<SetStateAction<number>>;
 }
 
-const RoomSelect = ({ setIsBtnDisabled, workplaceId }: RoomSelectProps) => {
+const RoomSelect = ({
+  setIsBtnDisabled,
+  workplaceId,
+  selectedRoomId,
+  setSelectedRoomId,
+}: RoomSelectProps) => {
   const { data } = useGetStudyroomOfWorkplace(workplaceId);
-  const navigate = useNavigate();
 
-  const [selectedRoomId, setSelectedRoomId] = useState<number>();
   const handleClick = (id: number) => {
     setIsBtnDisabled(false);
     setSelectedRoomId(id);
-    navigate(`/reservation/${id}`);
   };
 
   return (

--- a/src/pages/DetailPage/components/TabComponent.tsx
+++ b/src/pages/DetailPage/components/TabComponent.tsx
@@ -8,12 +8,16 @@ interface TabComponentProps {
   setIsBtnDisabled: Dispatch<SetStateAction<boolean>>;
   workplaceDetailData: GetWorkPlaceData;
   workplaceId: number;
+  selectedRoomId: number;
+  setSelectedRoomId: Dispatch<SetStateAction<number>>;
 }
 
 const TabComponent = ({
   setIsBtnDisabled,
   workplaceDetailData,
   workplaceId,
+  selectedRoomId,
+  setSelectedRoomId,
 }: TabComponentProps) => {
   const tabs = [
     '상세정보',
@@ -51,6 +55,8 @@ const TabComponent = ({
           <RoomSelect
             setIsBtnDisabled={setIsBtnDisabled}
             workplaceId={workplaceId}
+            selectedRoomId={selectedRoomId}
+            setSelectedRoomId={setSelectedRoomId}
           />
         )}
         {activeTab === 2 && (

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -11,6 +11,7 @@ const DetailPage = () => {
   const { workplaceId } = useParams() as { workplaceId: string };
   const { data, isLoading } = useGetWorkplaceData(Number(workplaceId));
   const [isBtnDisabled, setIsBtnDisabled] = useState(true);
+  const [selectedRoomId, setSelectedRoomId] = useState<number>(0);
 
   return (
     <MainLayout headerType='both'>
@@ -31,6 +32,8 @@ const DetailPage = () => {
               setIsBtnDisabled={setIsBtnDisabled}
               workplaceDetailData={data}
               workplaceId={Number(workplaceId)}
+              selectedRoomId={selectedRoomId}
+              setSelectedRoomId={setSelectedRoomId}
             />
           )}
         </div>
@@ -38,6 +41,7 @@ const DetailPage = () => {
       <DetailNavigation
         workplaceId={data?.workplaceId || 0}
         isBtnDisabled={isBtnDisabled}
+        selectedRoomId={selectedRoomId}
       />
     </MainLayout>
   );

--- a/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
+++ b/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
@@ -10,11 +10,14 @@ const useGetWorkplaceData = (
   nowPosition: NowPosition,
   mapPosition: MapPosition,
 ) => {
+  const isMapEnabled =
+    mapPosition.topRight.lat !== 0 || mapPosition.bottomLeft.lat !== 0;
   const { data, isLoading, isError, refetch } = useQuery<
     GetPositionWorkPlaceData[]
   >({
     queryKey: ['nearWorkplace', nowPosition, mapPosition],
     queryFn: () => postPositionWorkPlace({ nowPosition, mapPosition }),
+    enabled: isMapEnabled,
   });
 
   return { data, isLoading, isError, refetch };

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -4,11 +4,11 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useSearchStore from '@store/searchStore';
 import { toast } from 'react-toastify';
 import { ERROR_MESSAGE } from '@constants/constants';
+import { useEffect } from 'react';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
 import useGetStudyroomDetail from './hooks/useGetStudyroomDetail';
-import { useEffect } from 'react';
 
 const ReservationPage = () => {
   const navigate = useNavigate();

--- a/src/pages/SearchPage/components/SelectTime.tsx
+++ b/src/pages/SearchPage/components/SelectTime.tsx
@@ -14,11 +14,10 @@ const SelectTime = () => {
     return `${String(hour).padStart(2, '0')}:00`;
   });
 
-  const [possibleTimeList, setPossibleTimeList] = useState<string[]>([]);
+  const [possibleTimeList, setPossibleTimeList] = useState<string[]>(timeList);
 
   useEffect(() => {
     const todayDate = new Date();
-    setPossibleTimeList(timeList);
     const todayDateOnly = todayDate.toLocaleDateString('ko-KR', {
       year: 'numeric',
       month: '2-digit',

--- a/src/pages/SearchPage/components/SelectTime.tsx
+++ b/src/pages/SearchPage/components/SelectTime.tsx
@@ -1,7 +1,9 @@
 import useSearchStore from '@store/searchStore';
+import { useEffect, useState } from 'react';
 
 const SelectTime = () => {
-  const { searchTime, setTime, setFormattedTime } = useSearchStore();
+  const { searchDate, searchTime, setTime, setFormattedTime } =
+    useSearchStore();
   const times = { startTime: '09:00', endTime: '23:00' };
 
   const startHour: number = Number(times.startTime.split(':')[0]);
@@ -11,6 +13,34 @@ const SelectTime = () => {
     const hour = startHour + i;
     return `${String(hour).padStart(2, '0')}:00`;
   });
+
+  const [possibleTimeList, setPossibleTimeList] = useState<string[]>([]);
+
+  useEffect(() => {
+    const todayDate = new Date();
+    setPossibleTimeList(timeList);
+    const todayDateOnly = todayDate.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const searchDateOnly = searchDate.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+
+    // 오늘 날짜이면 현재 시간 이전에는 선택 안됨
+    if (todayDateOnly === searchDateOnly) {
+      const timeNow = todayDate.getHours();
+      const newPossibleTimeList = possibleTimeList.filter((time) => {
+        const hour = parseInt(time.split(':')[0], 10);
+        return hour > timeNow;
+      });
+      setPossibleTimeList(newPossibleTimeList);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDate]);
 
   const setTimeArray = (newArray: string[]) => {
     if (newArray.length === 0) {
@@ -81,7 +111,7 @@ const SelectTime = () => {
           <button
             key={timeItem}
             type='button'
-            className={`flex h-[30px] w-[62px] items-center justify-center rounded-[5px] border-[1px] border-subfont px-[14px] py-[6px] text-xs ${searchTime.find((item) => item === timeItem) ? 'bg-primary text-white' : 'bg-white'}`}
+            className={`flex h-[30px] w-[62px] items-center justify-center rounded-[5px] border-[1px] border-subfont px-[14px] py-[6px] text-xs ${searchTime.find((item) => item === timeItem) ? 'bg-primary text-white' : ''} ${possibleTimeList.includes(timeItem) ? '' : 'pointer-events-none bg-[#C3C3C3] bg-opacity-100 text-[#454545]'}`}
             onClick={() => handleSelectTime(timeItem)}
           >
             {timeItem}

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -379,12 +379,11 @@ export interface SendMessageRequest {
 
 // 메시지 조회 응답값
 export interface ChatMessageResponse {
-  messageId: number;
   roomId: number;
   sender: string;
   content: string;
   timestamp: string;
-  senderType: 'member' | 'business';
+  isRead: boolean;
 }
 
 // 채팅목록 조회 응답값 (사용자)


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 검색페이지 현재 시간 이전 시 시간 블럭 선택 안되도록 개선
- 상세페이지에서 룸카드 선택 개선
- 지도 첫 요청 시 위치값 0으로 요청되는 것 개선

## 📝 요구 사항과 구현 내용
- 검색 페이지에서도 현재 시간을 기준으로 이전에는 선택이 안되도록 수정
- 상세페이지에서 룸카드 클릭 시 바로 페이지 이동이 아니라, '룸 선택하기' 버튼을 누르면 이동하도록 수정
- 지도 첫 요청 시 위치값 0일 때는 요청 안되도록 enabled 설정 (백엔드에서 0 값을 받으면 에러가 남 .. 갑자기 ..)

## 💬 PR 포인트 & 궁금한 점
- 졸려서 그런지 이슈번호랑 브랜치가 엉망진창 ... 죄송합니다 ...

## 🔗 연관된 이슈
- close #110  