### PR TITLE
🔧 Fix, ♻️ Refactor : 메인 및 검색 페이지 개선

### DIFF
--- a/src/apis/chat.ts
+++ b/src/apis/chat.ts
@@ -1,4 +1,8 @@
-import { ChatListResponse, ChatMessageResponse } from '@typings/types';
+import {
+  ChatListBusiness,
+  ChatListMember,
+  ChatMessageResponse,
+} from '@typings/types';
 import { authInstance } from '.';
 
 // 메시지 기록 조회
@@ -9,8 +13,14 @@ export const getMessage = async (
   return response.data;
 };
 
-// 채팅방 목록 조회
-export const getChatList = async (): Promise<ChatListResponse[]> => {
+// 채팅방 목록 조회 (사용자)
+export const getChatListMember = async (): Promise<ChatListMember[]> => {
+  const response = await authInstance.get('/api/v1/chat/room');
+  return response.data;
+};
+
+// 채팅방 목록 조회 (사업자)
+export const getChatListBusiness = async (): Promise<ChatListBusiness[]> => {
   const response = await authInstance.get('/api/v1/chat/room');
   return response.data;
 };

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -174,6 +174,7 @@ export const getPossibleTime = async (
   studyRoomId: number,
   checkDate: Date,
 ): Promise<PossibleTime> => {
+  checkDate.setHours(checkDate.getHours() + 9);
   const formattedDate = checkDate.toISOString().split('T')[0];
   const response = await defaultInstance.get(
     `api/v1/studyroom/search/${studyRoomId}`,

--- a/src/apis/workplace.ts
+++ b/src/apis/workplace.ts
@@ -174,8 +174,7 @@ export const getPossibleTime = async (
   studyRoomId: number,
   checkDate: Date,
 ): Promise<PossibleTime> => {
-  checkDate.setHours(checkDate.getHours() + 9);
-  const formattedDate = checkDate.toISOString().split('T')[0];
+  const formattedDate = `${checkDate.getFullYear()}-${(checkDate.getMonth() + 1).toString().padStart(2, '0')}-${checkDate.getDate().toString().padStart(2, '0')}`;
   const response = await defaultInstance.get(
     `api/v1/studyroom/search/${studyRoomId}`,
     {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -6,6 +6,10 @@ interface MainLayoutProps {
 }
 
 const MainLayout = ({ children, headerType = 'default' }: MainLayoutProps) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   const paddingTop = headerType === 'both' ? 'pt-[132px]' : 'pt-[93px]';
 
   return (

--- a/src/pages/ChatListPage/components/ChatCard.tsx
+++ b/src/pages/ChatListPage/components/ChatCard.tsx
@@ -1,17 +1,18 @@
-import { ChatListResponse } from '@typings/types';
+import { ChatListBusiness, ChatListMember } from '@typings/types';
 import { getDateFunction } from '@utils/formatTime';
 import { GrNext } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';
 
 interface ChatCardProps {
-  chat: ChatListResponse;
+  chat: ChatListMember | ChatListBusiness;
 }
 const ChatCard = (props: ChatCardProps) => {
   const { chat } = props;
-
+  const userName =
+    'memberNickname' in chat ? chat.memberNickname : chat.workplaceName;
   const navigate = useNavigate();
   const handleClickChat = () => {
-    navigate(`/chat/${chat.roomId}`, { state: chat.name });
+    navigate(`/chat/${chat.roomId}`, { state: userName });
   };
 
   return (
@@ -26,7 +27,7 @@ const ChatCard = (props: ChatCardProps) => {
             type='button'
             className='flex items-center gap-1 text-sm font-medium'
           >
-            {chat.name} <GrNext className='text-xs' />
+            {userName} <GrNext className='text-xs' />
           </button>
           <span className='text-xs text-subfont'>
             {getDateFunction(chat.updatedAt)}
@@ -34,8 +35,7 @@ const ChatCard = (props: ChatCardProps) => {
         </div>
         <div className='flex items-center justify-between'>
           <div className='w-64 text-xs text-focusColor'>
-            안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요.
-            안녕하세요. 안녕하세요. 안녕하세요. 안.....
+            {chat.messageContent}
           </div>
           <span className='h-2 w-2 rounded-full bg-[#F83A3A]' />
         </div>

--- a/src/pages/ChatListPage/components/ChatCard.tsx
+++ b/src/pages/ChatListPage/components/ChatCard.tsx
@@ -9,7 +9,7 @@ interface ChatCardProps {
 const ChatCard = (props: ChatCardProps) => {
   const { chat } = props;
   const userName =
-    'memberNickname' in chat ? chat.memberNickname : chat.workplaceName;
+    'memberId' in chat ? chat.memberNickname : chat.workplaceName;
   const navigate = useNavigate();
   const handleClickChat = () => {
     navigate(`/chat/${chat.roomId}`, { state: userName });

--- a/src/pages/ChatListPage/hooks/useGetChatList.ts
+++ b/src/pages/ChatListPage/hooks/useGetChatList.ts
@@ -1,12 +1,16 @@
-import { getChatList } from '@apis/chat';
+import { getChatListBusiness, getChatListMember } from '@apis/chat';
 import { useQuery } from '@tanstack/react-query';
-import { ChatListResponse } from '@typings/types';
+import { ChatListBusiness, ChatListMember } from '@typings/types';
+import { getRole } from '@utils/auth';
 
 const useGetChatList = () => {
-  const { data, isLoading, isError } = useQuery<ChatListResponse[]>({
-    queryKey: ['chatList'],
-    queryFn: () => getChatList(),
-  });
+  const role = getRole();
+  const queryKey = ['chatList'];
+  const queryFn =
+    role === 'ROLE_USER' ? getChatListMember : getChatListBusiness;
+  const { data, isLoading, isError } = useQuery<
+    ChatListMember[] | ChatListBusiness[]
+  >({ queryKey, queryFn });
 
   return { data: data ?? [], isLoading, isError };
 };

--- a/src/pages/ChatListPage/hooks/useGetChatList.ts
+++ b/src/pages/ChatListPage/hooks/useGetChatList.ts
@@ -5,7 +5,7 @@ import { getRole } from '@utils/auth';
 
 const useGetChatList = () => {
   const role = getRole();
-  const queryKey = ['chatList'];
+  const queryKey = ['chatList', role];
   const queryFn =
     role === 'ROLE_USER' ? getChatListMember : getChatListBusiness;
   const { data, isLoading, isError } = useQuery<

--- a/src/pages/ChatPage/components/ReceiveMessage.tsx
+++ b/src/pages/ChatPage/components/ReceiveMessage.tsx
@@ -6,11 +6,11 @@ interface ReceiveMessageProps {
 
 const ReceiveMessage = (props: ReceiveMessageProps) => {
   const { message } = props;
-  const formattedTime = message.timestamp
-    .split('T')[1]
-    .split(':')
-    .slice(0, 2)
-    .join(':');
+  const formattedTime = message.timestamp;
+  // .split('T')[1]
+  // .split(':')
+  // .slice(0, 2)
+  // .join(':');
   return (
     <div className='flex w-custom justify-start'>
       <div className='flex items-end gap-2'>

--- a/src/pages/ChatPage/components/SendMessage.tsx
+++ b/src/pages/ChatPage/components/SendMessage.tsx
@@ -6,11 +6,11 @@ interface SendMessageProps {
 
 const SendMessage = (props: SendMessageProps) => {
   const { message } = props;
-  const formattedTime = message.timestamp
-    .split('T')[1]
-    .split(':')
-    .slice(0, 2)
-    .join(':');
+  const formattedTime = message.timestamp;
+  // .split('T')[1]
+  // .split(':')
+  // .slice(0, 2)
+  // .join(':');
   return (
     <div className='flex w-custom justify-end'>
       <div className='flex items-end gap-2'>

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -94,7 +94,7 @@ const ChatPage = () => {
         content: inputValue,
         roomId: parseInt(roomId || '', 10),
         timestamp: getDatetoLocalDate(new Date()),
-        senderType: role === 'ROLE_USER' ? 'member' : 'business',
+        senderType: role === 'ROLE_USER' ? 'MEMBER' : 'BUSINESS',
       };
 
       stompClient.publish({

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -60,7 +60,7 @@ const ChatPage = () => {
       client.onConnect = () => {
         console.log('Connected');
 
-        client.subscribe(`/sub/chat`, (message: IMessage) => {
+        client.subscribe(`/sub/chat/${roomId}`, (message: IMessage) => {
           try {
             const newMessage = JSON.parse(message.body);
             setMessages((prevMessages) => [...prevMessages, newMessage]);

--- a/src/pages/DetailPage/components/DetailNavigation.tsx
+++ b/src/pages/DetailPage/components/DetailNavigation.tsx
@@ -1,4 +1,7 @@
 import { postCreateChatRoom } from '@apis/chat';
+import useAuthStore from '@store/authStore';
+import { getRole } from '@utils/auth';
+import { useEffect, useState } from 'react';
 import { IoChatbubbleEllipsesOutline } from 'react-icons/io5';
 import { useNavigate } from 'react-router-dom';
 
@@ -23,25 +26,41 @@ const DetailNavigation = ({
     navigate(`/reservation/${selectedRoomId}`);
   };
 
+  // 사용자 / 사업자인지 확인
+  const { isLogin } = useAuthStore();
+  const [isUser, setIsUser] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isLogin) {
+      const role = getRole();
+      if (role === 'ROLE_USER') {
+        setIsUser(true);
+      }
+    }
+  }, [isLogin]);
+
   return (
     <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-center border-t border-subfont bg-white pb-[16px]'>
-      <div className='flex'>
+      <div className='flex items-center gap-2'>
+        {isUser && (
+          <button
+            type='button'
+            className='flex h-[48px] w-[100px] items-center justify-center rounded-[8px] border border-primary'
+            onClick={handleClickChat}
+          >
+            <IoChatbubbleEllipsesOutline
+              size='20px'
+              color='#50BEAD'
+            />
+            <p className='ml-[4px] text-[16px] font-medium text-primary'>
+              1 : 1 문의
+            </p>
+          </button>
+        )}
+
         <button
           type='button'
-          className='flex h-[48px] w-[100px] items-center justify-center rounded-[8px] border border-primary'
-          onClick={handleClickChat}
-        >
-          <IoChatbubbleEllipsesOutline
-            size='20px'
-            color='#50BEAD'
-          />
-          <p className='ml-[4px] text-[16px] font-medium text-primary'>
-            1 : 1 문의
-          </p>
-        </button>
-        <button
-          type='button'
-          className={`ml-[8px] w-[222px] rounded-[8px] text-white ${isBtnDisabled ? 'bg-subfont' : 'bg-primary'}`}
+          className={`h-[48px] rounded-[8px] text-white ${isBtnDisabled ? 'bg-subfont' : 'bg-primary'} ${isUser ? 'w-[222px]' : 'pointer-events-none w-custom bg-subfont'}`}
           disabled={isBtnDisabled}
           onClick={handleSelectRoom}
         >

--- a/src/pages/DetailPage/components/DetailNavigation.tsx
+++ b/src/pages/DetailPage/components/DetailNavigation.tsx
@@ -41,12 +41,9 @@ const DetailNavigation = ({
         </button>
         <button
           type='button'
-          className='ml-[8px] w-[222px] rounded-[8px] text-white'
+          className={`ml-[8px] w-[222px] rounded-[8px] text-white ${isBtnDisabled ? 'bg-subfont' : 'bg-primary'}`}
           disabled={isBtnDisabled}
           onClick={handleSelectRoom}
-          style={{
-            backgroundColor: isBtnDisabled === false ? '#50BEAD' : '#c3c3c3',
-          }}
         >
           룸 선택하기
         </button>

--- a/src/pages/DetailPage/components/RoomSelect.tsx
+++ b/src/pages/DetailPage/components/RoomSelect.tsx
@@ -24,7 +24,7 @@ const RoomSelect = ({
 
   return (
     <div className='w-custom'>
-      {data ? (
+      {data && data.length > 0 ? (
         data.map((item) => (
           <button
             key={item.studyRoomId}

--- a/src/pages/DetailPage/components/RoomSelect.tsx
+++ b/src/pages/DetailPage/components/RoomSelect.tsx
@@ -42,7 +42,9 @@ const RoomSelect = ({
           </button>
         ))
       ) : (
-        <p>조회된 룸이 없습니다.</p>
+        <div className='flex h-[150px] w-full items-center justify-center font-normal text-subfont'>
+          조회된 룸이 없습니다.
+        </div>
       )}
     </div>
   );

--- a/src/pages/DetailPage/components/TabComponent.tsx
+++ b/src/pages/DetailPage/components/TabComponent.tsx
@@ -61,7 +61,7 @@ const TabComponent = ({
         )}
         {activeTab === 2 &&
           (workplaceDetailData.reviewCount === 0 ? (
-            <div className='text-[16px] font-normal text-subfont'>
+            <div className='flex h-[150px] w-full items-center justify-center font-normal text-subfont'>
               등록된 리뷰가 없습니다.
             </div>
           ) : (

--- a/src/pages/MainPage/components/KakaoMap.tsx
+++ b/src/pages/MainPage/components/KakaoMap.tsx
@@ -77,6 +77,9 @@ const KakaoMap = (props: KakaoMapProps) => {
     setIsModalOpen(false);
   }, []);
 
+  // 지도에 표시할 데이터
+  const markerData = activeTab === '주변 스터디룸' ? data : recommendData;
+
   return (
     <div className='relative h-[298px] w-[375px]'>
       <Map
@@ -90,27 +93,9 @@ const KakaoMap = (props: KakaoMapProps) => {
           setCenterPosition({ lat: latlng.getLat(), lng: latlng.getLng() });
         }}
       >
-        {activeTab === '주변 스터디룸' &&
-          data &&
-          data.length > 0 &&
-          data.map((item) => (
-            <MapMarker
-              onClick={() => handleMarkerClick(item)}
-              key={item.positionLat}
-              position={{ lat: item.positionLat, lng: item.positionLon }}
-              image={{
-                src: 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
-                size: {
-                  width: 24,
-                  height: 35,
-                },
-              }}
-            />
-          ))}
-        {activeTab === '맞춤형 추천' &&
-          recommendData &&
-          recommendData.length > 0 &&
-          recommendData.map((item) => (
+        {markerData &&
+          markerData.length > 0 &&
+          markerData.map((item) => (
             <MapMarker
               onClick={() => handleMarkerClick(item)}
               key={item.positionLat}

--- a/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
+++ b/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
@@ -1,6 +1,7 @@
 import { getRecommendWorkPlace, postPositionWorkPlace } from '@apis/workplace';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import {
+  CenterPosition,
   GetPositionWorkPlaceData,
   MapPosition,
   NowPosition,
@@ -9,15 +10,17 @@ import {
 export const useGetWorkplaceData = (
   nowPosition: NowPosition,
   mapPosition: MapPosition,
+  centerPosition: CenterPosition,
 ) => {
   const isMapEnabled =
     mapPosition.topRight.lat !== 0 || mapPosition.bottomLeft.lat !== 0;
   const { data, isLoading, isError, refetch } = useQuery<
     GetPositionWorkPlaceData[]
   >({
-    queryKey: ['nearWorkplace', nowPosition, mapPosition],
+    queryKey: ['nearWorkplace', nowPosition, mapPosition, centerPosition],
     queryFn: () => postPositionWorkPlace({ nowPosition, mapPosition }),
     enabled: isMapEnabled,
+    placeholderData: keepPreviousData,
   });
 
   return { data, isLoading, isError, refetch };

--- a/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
+++ b/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
@@ -23,11 +23,15 @@ export const useGetWorkplaceData = (
   return { data, isLoading, isError, refetch };
 };
 
-export const useGetRecommendData = (isLogin: boolean, isUser: boolean) => {
+export const useGetRecommendData = (
+  isLogin: boolean,
+  isUser: boolean,
+  activeTab: string,
+) => {
   const { data, isLoading, isError } = useQuery<GetPositionWorkPlaceData[]>({
     queryKey: ['recommendWorkPlace', isLogin, isUser],
     queryFn: () => getRecommendWorkPlace(),
-    enabled: isLogin && isUser,
+    enabled: isLogin && isUser && activeTab !== '주변 스터디룸',
   });
 
   return {

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,7 +1,6 @@
 import MainLayout from '@layouts/MainLayout';
 import HeaderNoTitle from '@layouts/HeaderNoTitle';
 import BottomNavigation from '@layouts/BottomNavigation';
-import { useEffect } from 'react';
 import usePositionStore from '@store/positionStore';
 import MainList from './components/MainList';
 import KakaoMap from './components/KakaoMap';
@@ -19,11 +18,6 @@ const MainPage = () => {
     position,
     mapPosition,
   );
-
-  // 스크롤 상단으로 이동
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
 
   return (
     <>

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -24,7 +24,7 @@ const MainPage = () => {
   const { data, isLoading, isError } = useGetWorkplaceData(
     position,
     mapPosition,
-    centerPosition
+    centerPosition,
   );
 
   // 비로그인 / 사업자 / 사용자 확인

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -39,15 +39,15 @@ const MainPage = () => {
     }
   }, [isLogin]);
 
+  // 선택한 탭
+  const [activeTab, setActiveTab] = useState('주변 스터디룸');
+
   // 사업장 추천 데이터
   const {
     data: recommendData,
     isLoading: isRecommendLoading,
     isError: isRecommendError,
-  } = useGetRecommendData(isLogin, isUser);
-
-  // 선택한 탭
-  const [activeTab, setActiveTab] = useState('주변 스터디룸');
+  } = useGetRecommendData(isLogin, isUser, activeTab);
 
   return (
     <>

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -13,7 +13,7 @@ import {
 } from './hooks/useGetWorkplaceData';
 
 const MainPage = () => {
-  const { mapPosition, nowPosition } = usePositionStore();
+  const { mapPosition, nowPosition, centerPosition } = usePositionStore();
 
   const position = {
     latitude: nowPosition.center.lat,
@@ -24,6 +24,7 @@ const MainPage = () => {
   const { data, isLoading, isError } = useGetWorkplaceData(
     position,
     mapPosition,
+    centerPosition
   );
 
   // 비로그인 / 사업자 / 사용자 확인

--- a/src/pages/ManagementReserverPage/components/ReserverCard.tsx
+++ b/src/pages/ManagementReserverPage/components/ReserverCard.tsx
@@ -23,9 +23,14 @@ const ReserverCard = ({ item }: { item: ReserverInfo }) => {
     <div className='mx-auto flex w-custom flex-col gap-2 border-b border-solid border-b-black px-[13px] py-[26px]'>
       <div className='flex justify-between'>
         <div className='flex flex-col items-start gap-4'>
-          <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-            <Link to={`/detail/${workplaceId}`}>{workplaceName}</Link>
-            <MdArrowForwardIos className='w-3' />
+          <div className='flex cursor-pointer items-center font-medium'>
+            <Link
+              to={`/detail/${workplaceId}`}
+              className='flex items-center gap-1.5'
+            >
+              {workplaceName}
+              <MdArrowForwardIos className='w-3' />
+            </Link>
           </div>
 
           <ul className='flex flex-col gap-1 text-[12px]'>

--- a/src/pages/PaymentPage/PaymentLoadingPage.tsx
+++ b/src/pages/PaymentPage/PaymentLoadingPage.tsx
@@ -17,9 +17,7 @@ const PaymentLoadingPage = () => {
 
     const paymentsSuccess = async () => {
       if (requestData.orderId && requestData.amount && requestData.paymentKey) {
-        console.log(requestData);
         const response = await getPaymentsSuccess(requestData);
-        console.log(response);
         navigate('/payment-success', { state: response });
       } else {
         throw new Error('결제에 필요한 값이 누락되었습니다.');

--- a/src/pages/PaymentPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentPage/PaymentSuccessPage.tsx
@@ -8,8 +8,6 @@ const PaymentSuccessPage = () => {
 
   const { orderName, totalAmount } = responseData;
 
-  console.log('Response Data:', responseData);
-
   const formattedAmount = `${totalAmount.toLocaleString('ko-KR')}원`;
 
   return (

--- a/src/pages/PaymentPage/PaymentSuccessPage.tsx
+++ b/src/pages/PaymentPage/PaymentSuccessPage.tsx
@@ -16,10 +16,10 @@ const PaymentSuccessPage = () => {
         <div className='flex w-custom flex-col items-center justify-center gap-3'>
           <div className='text-xl font-medium'>결제 완료</div>
           <div>결제가 정상적으로 처리되었습니다.</div>
-          <div className='mt-3 flex w-[220px] flex-col gap-1 text-sm'>
+          <div className='mt-3 flex w-[250px] flex-col gap-1 text-sm'>
             <div className='flex justify-between'>
               <p className='font-medium'>주문 상품</p>
-              <p className='w-[150px] text-end'>{orderName}</p>
+              <p className='w-[180px] text-end'>{orderName}</p>
             </div>
             <div className='flex justify-between'>
               <p className='font-medium'>결제 금액</p>

--- a/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
+++ b/src/pages/ReservationListPage/components/ReservationDetailCard.tsx
@@ -92,11 +92,15 @@ const ReservationDetailCard = ({ item }: { item: Reservation }) => {
     <>
       <div className='mx-auto flex w-custom flex-col gap-[18px] border-b border-solid border-b-black px-[13px] py-[24px]'>
         <div className='flex w-[auto] flex-col gap-4'>
-          <span className='flex items-center gap-1 text-[16px] font-medium'>
-            <Link to={`/detail/${workplaceId}`}>{workplaceName}</Link>
-            <MdArrowForwardIos />
+          <span className='flex items-center text-[16px] font-medium'>
+            <Link
+              to={`/detail/${workplaceId}`}
+              className='flex items-center gap-1.5'
+            >
+              {workplaceName}
+              <MdArrowForwardIos className='w-3' />
+            </Link>
           </span>
-
           <div className='flex items-center justify-between'>
             <ul className='flex flex-col gap-1 text-[12px]'>
               <ListStyle

--- a/src/pages/ReservationPage/components/ImageCarousel.tsx
+++ b/src/pages/ReservationPage/components/ImageCarousel.tsx
@@ -32,7 +32,7 @@ const ImageCarousel = (props: ImageCarouselProps) => {
 
   return (
     <>
-      <div className='relative mx-auto mt-8 w-custom'>
+      <div className='relative mt-8 w-[375px]'>
         {roomImageList && roomImageList.length > 0 && (
           <>
             <img
@@ -40,7 +40,7 @@ const ImageCarousel = (props: ImageCarouselProps) => {
               alt='룸 사진'
               className='pointer-events-none h-[240px] w-full select-none object-cover'
             />
-            <div className='absolute top-[100px] flex w-custom items-center justify-between text-4xl text-white opacity-70'>
+            <div className='absolute top-[100px] flex w-[375px] cursor-pointer items-center justify-between text-4xl text-white opacity-70'>
               <GrPrevious onClick={handleSlidePrev} />
               <GrNext onClick={handleSlideNext} />
             </div>

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useSearchStore from '@store/searchStore';
 import { toast } from 'react-toastify';
 import { ERROR_MESSAGE } from '@constants/constants';
-import { useEffect } from 'react';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
@@ -34,11 +33,6 @@ const ReservationPage = () => {
     }
     navigate('/payment', { state: studyRoomInfo });
   };
-
-  // 스크롤 상단으로 이동
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
 
   return (
     <MainLayout>

--- a/src/pages/ReservationPage/index.tsx
+++ b/src/pages/ReservationPage/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useSearchStore from '@store/searchStore';
 import { toast } from 'react-toastify';
 import { ERROR_MESSAGE } from '@constants/constants';
+import useAuthStore from '@store/authStore';
 import ReservationBar from './components/ReservationBar';
 import ImageCarousel from './components/ImageCarousel';
 import RoomDetail from './components/RoomDetail';
@@ -34,6 +35,8 @@ const ReservationPage = () => {
     navigate('/payment', { state: studyRoomInfo });
   };
 
+  const { isLogin } = useAuthStore();
+
   return (
     <MainLayout>
       <HeaderOnlyTitle title={data?.studyRoomName || '스터디룸'} />
@@ -43,7 +46,7 @@ const ReservationPage = () => {
       <div className='fixed bottom-0 z-10 flex h-[94px] w-[375px] items-center justify-between border-t-[1px] border-t-subfont bg-white px-[30px] pb-[30px] pt-[18px]'>
         <button
           type='button'
-          className='btn-primary'
+          className={`btn-primary ${isLogin ? '' : 'pointer-events-none bg-subfont font-normal'}`}
           onClick={handleClickReservation}
         >
           예약하기

--- a/src/pages/ReviewListPage/components/MyReviewCard.tsx
+++ b/src/pages/ReviewListPage/components/MyReviewCard.tsx
@@ -29,9 +29,14 @@ const MyReviewCard = ({ item }: { item: Review }) => {
   return (
     <div className='mx-auto flex w-custom flex-col gap-[13px] border-b border-solid border-b-black px-[13px] py-[26px]'>
       <div className='flex items-start justify-between'>
-        <div className='flex cursor-pointer items-center gap-1.5 font-medium'>
-          <Link to={`/detail/${workplaceId}`}>{workplaceName}</Link>
-          <MdArrowForwardIos className='w-3' />
+        <div className='flex cursor-pointer items-center font-medium'>
+          <Link
+            to={`/detail/${workplaceId}`}
+            className='flex items-center gap-1.5'
+          >
+            {workplaceName}
+            <MdArrowForwardIos className='w-3' />
+          </Link>
         </div>
         <img
           src={workplaceImageURL}

--- a/src/pages/SearchPage/components/PlaceSearch.tsx
+++ b/src/pages/SearchPage/components/PlaceSearch.tsx
@@ -25,12 +25,6 @@ const PlaceSearch = () => {
     ps.keywordSearch(searchPlace, (data, status) => {
       if (status === kakao.maps.services.Status.OK) {
         setSearchList(data);
-        console.log(data);
-      } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
-        console.log('검색 결과가 존재하지 않습니다.');
-        setSearchList([]);
-      } else if (status === kakao.maps.services.Status.ERROR) {
-        console.log('검색 결과 중 오류가 발생했습니다.');
       }
     });
   }, [searchPlace]);

--- a/src/pages/SearchPage/components/SelectTime.tsx
+++ b/src/pages/SearchPage/components/SelectTime.tsx
@@ -17,6 +17,7 @@ const SelectTime = () => {
   const [possibleTimeList, setPossibleTimeList] = useState<string[]>(timeList);
 
   useEffect(() => {
+    setPossibleTimeList(timeList);
     const todayDate = new Date();
     const todayDateOnly = todayDate.toLocaleDateString('ko-KR', {
       year: 'numeric',

--- a/src/pages/SearchResult/index.tsx
+++ b/src/pages/SearchResult/index.tsx
@@ -4,7 +4,6 @@ import MainLayout from '@layouts/MainLayout';
 import { SearchStudyRoom } from '@typings/types';
 import useSearchStore from '@store/searchStore';
 import { SyncLoader } from 'react-spinners';
-import { useEffect } from 'react';
 import ResultBar from './components/ResultBar';
 import RoomCard from './components/RoomCard';
 import { useGetSearchStudyRoom } from './hooks/useGetSearchStudyRoom';
@@ -28,11 +27,6 @@ const SearchResult = () => {
   };
 
   const { data, isLoading } = useGetSearchStudyRoom(searchData);
-
-  // 스크롤 상단으로 이동
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
 
   return (
     <>

--- a/src/pages/WriteReviewPage/components/ReservationInfo.tsx
+++ b/src/pages/WriteReviewPage/components/ReservationInfo.tsx
@@ -1,5 +1,5 @@
 import ListStyle from '@components/ListStyle';
-import { WriteReviewProps } from '..';
+import type { WriteReviewProps } from '..';
 
 const ReservationInfo = ({ item }: { item: WriteReviewProps }) => {
   const {

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -387,9 +387,21 @@ export interface ChatMessageResponse {
 }
 
 // 채팅목록 조회 응답값 (사용자)
-export interface ChatListResponse {
+export interface ChatListMember {
   roomId: number;
-  id: number;
-  name: string;
+  businessId: number;
+  workplaceName: string;
+  messageContent: string | null;
+  isRead: boolean;
+  updatedAt: string;
+}
+
+// 채팅목록 조회 응답값 (사업자)
+export interface ChatListBusiness {
+  roomId: number;
+  memberId: number;
+  memberNickname: string;
+  messageContent: string | null;
+  isRead: boolean;
   updatedAt: string;
 }

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -374,7 +374,7 @@ export interface SendMessageRequest {
   sender: string;
   content: string;
   timestamp: string;
-  senderType: 'member' | 'business';
+  senderType: 'MEMBER' | 'BUSINESS';
 }
 
 // 메시지 조회 응답값


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 제가 맡은 페이지랑 다른 페이지 이리저리 이동해보면서 조금씩 수정했습니다.

## 📝 요구 사항과 구현 내용
- 상단 스크롤 이동 메인 레이아웃에 추가 및 다른 페이지에서 삭제
- 예약 가능한 시간대 날짜 요청이 하루 전날로 가는 것 개선
- 검색 페이지에서 시간 블럭 업데이트 안되는 것 개선
- '조회된 룸이 없습니다', '등록된 리뷰가 없습니다' 문구 스타일 통일 및 빈 배열일 때도 처리 `성령님 파트`
- 메인페이지 '맞춤형 추천' 탭 클릭 시 요청 가도록 개선 (기존에는 메인페이지 로딩 시에 바로 요청 보냈음)
- 현재 위치로 이동하는 버튼 클릭 시에도 위치 기반 데이터 재요청 하도록 개선 (기존에는 버튼 클릭 시에도 아무 요청 X)
- 지도 이동할 때마다 깜빡이는 것 개선 (트러블 슈팅 참고)
- 로그인 안했을 때 '예약하기' 버튼 막아서 예약 못하도록 개선
- 결제 완료 페이지 주문 상품 안내 너비 수정
- 클릭 시 이동하는 것 화살표 아이콘까지 적용되도록 개선 `현진님 파트`
- 사업자 일 때는 '1:1 문의' 버튼과 룸 선택 안되도록 개선 `성령님 파트`

## ✅ 피드백 반영사항
- 예약 페이지 이미지 캐러셀 너비 375px로 수정했습니다 ‼️

## 💬 PR 포인트 & 궁금한 점
- 제 쪽에서는 console.log 다 제거했습니다, 각자 페이지 확인해주세요.
- 성령님 DetailNavigation.tsx에서 인라인 스타일 쓰고 있길래 수정했습니다 ~
- 위에 적힌 각자 맡은 페이지 확인하시고 문제 있으면 말씀해주세요.

## 🔗 연관된 이슈
- close #113 