### PR TITLE
♻️ Refactor : 최근 7일 이내 알림 구분선 추가

### DIFF
--- a/src/components/LogoAndNotification.tsx
+++ b/src/components/LogoAndNotification.tsx
@@ -11,7 +11,6 @@ interface HeaderProps {
 const LogoAndNotification = ({ isLogin }: HeaderProps) => {
   const navigate = useNavigate();
   const role = getRole();
-  // const { activeNoti } = useNotificationStore();
 
   const handleMoveToNotiPageClick = () => {
     if (role === 'ROLE_USER') {

--- a/src/pages/HostNotiPage/components/HostNotiList.tsx
+++ b/src/pages/HostNotiPage/components/HostNotiList.tsx
@@ -1,5 +1,7 @@
 import { SyncLoader } from 'react-spinners';
 import { AiFillInfoCircle } from 'react-icons/ai';
+import { getWithinSevenDays } from '@utils/formatTime';
+import ShowWithinSevenDays from '@components/ShowWithinSevenDays';
 import useGetBusinessNotification from '../hooks/useGetBusinessNotification';
 import HostReservationNotiCard from './HostReservationNotiCard';
 import HostReviewNotiCard from './HostReviewNotiCard';
@@ -26,20 +28,34 @@ const HostNotiList = () => {
                 ? `review-${item.reviewId || index}`
                 : `reservation-${item.reservationId || index}`;
 
+            const prevItem = sortedNotification[index - 1];
+
+            // 구분선 표시 조건
+            const showDivider =
+              prevItem &&
+              getWithinSevenDays(prevItem.createdAt) &&
+              !getWithinSevenDays(item.createdAt);
+
             if (item.notificationType === 'REVIEW_CREATED') {
               return (
-                <HostReviewNotiCard
-                  key={uniqueKey}
-                  item={item}
-                />
+                <>
+                  {showDivider && <ShowWithinSevenDays label='최근 7일' />}
+                  <HostReviewNotiCard
+                    key={uniqueKey}
+                    item={item}
+                  />
+                </>
               );
             }
 
             return (
-              <HostReservationNotiCard
-                key={uniqueKey}
-                item={item}
-              />
+              <>
+                {showDivider && <ShowWithinSevenDays label='최근 7일' />}
+                <HostReservationNotiCard
+                  key={uniqueKey}
+                  item={item}
+                />
+              </>
             );
           })}
         </div>

--- a/src/pages/HostNotiPage/components/HostNotiList.tsx
+++ b/src/pages/HostNotiPage/components/HostNotiList.tsx
@@ -1,4 +1,5 @@
 import { SyncLoader } from 'react-spinners';
+import { AiFillInfoCircle } from 'react-icons/ai';
 import useGetBusinessNotification from '../hooks/useGetBusinessNotification';
 import HostReservationNotiCard from './HostReservationNotiCard';
 import HostReviewNotiCard from './HostReviewNotiCard';
@@ -14,6 +15,11 @@ const HostNotiList = () => {
     <>
       {sortedNotification && sortedNotification.length > 0 ? (
         <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px] pb-24'>
+          <div className='mx-auto flex w-custom items-center gap-1 self-start pl-[6px] text-sm text-subfont'>
+            <AiFillInfoCircle />
+            3달이 경과된 알림은 자동 삭제처리됩니다.
+          </div>
+          <hr className='mx-[22.5px] w-custom border-[0.5px] border-dashed' />
           {sortedNotification.map((item, index) => {
             const uniqueKey =
               item.notificationType === 'REVIEW_CREATED'

--- a/src/pages/HostNotiPage/components/HostReviewNotiCard.tsx
+++ b/src/pages/HostNotiPage/components/HostReviewNotiCard.tsx
@@ -16,7 +16,7 @@ const HostReviewNotiCard = ({ item }: HostNotiProps) => {
           <div className='mx-auto w-custom px-1.5 py-[13px]'>
             <p className='font-medium'>새 리뷰 등록</p>
 
-            <div className='flex flex-col gap-1'>
+            <div className='mt-2 flex flex-col gap-1'>
               <p className='text-xs text-subfont'>
                 {getDateFunction(createdAt)}
               </p>

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -1,4 +1,5 @@
 import { SyncLoader } from 'react-spinners';
+import { AiFillInfoCircle } from 'react-icons/ai';
 import UserNotiCard from './UserNotiCard';
 import useGetUserAlarm from '../hooks/useGetUserAlarm';
 
@@ -13,6 +14,11 @@ const UserNotiList = () => {
     <>
       {sortedNotification && sortedNotification.length > 0 ? (
         <div className='mt-4 flex w-[375px] flex-col justify-center gap-[13px] pb-24'>
+          <div className='mx-auto flex w-custom items-center gap-1 self-start pl-[6px] text-sm text-subfont'>
+            <AiFillInfoCircle />
+            3달이 경과된 알림은 자동 삭제처리됩니다.
+          </div>
+          <hr className='mx-[22.5px] w-custom border-[0.5px] border-dashed' />
           {sortedNotification.map((item) => {
             return (
               <UserNotiCard

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -1,10 +1,14 @@
 import { SyncLoader } from 'react-spinners';
 import { AiFillInfoCircle } from 'react-icons/ai';
+import { getWithinSevenDays } from '@utils/formatTime';
+import ShowWithinSevenDays from '@components/ShowWithinSevenDays';
+import { useState } from 'react';
 import UserNotiCard from './UserNotiCard';
 import useGetUserAlarm from '../hooks/useGetUserAlarm';
 
 const UserNotiList = () => {
   const { data: userAlarmList, isLoading } = useGetUserAlarm();
+  const [isLabel, setIsLabel] = useState(false);
 
   const sortedNotification = userAlarmList?.sort((b, a) => {
     return +new Date(a.createdAt) - +new Date(b.createdAt);
@@ -21,10 +25,15 @@ const UserNotiList = () => {
           <hr className='mx-[22.5px] w-custom border-[0.5px] border-dashed' />
           {sortedNotification.map((item) => {
             return (
-              <UserNotiCard
-                key={item.memberalrimId}
-                item={item}
-              />
+              <>
+                <UserNotiCard
+                  key={item.memberalrimId}
+                  item={item}
+                />
+                {!isLabel && getWithinSevenDays(item.createdAt) && (
+                  <ShowWithinSevenDays label='최근 7일' />
+                )}
+              </>
             );
           })}
         </div>

--- a/src/pages/UserNotiPage/components/UserNotiList.tsx
+++ b/src/pages/UserNotiPage/components/UserNotiList.tsx
@@ -2,13 +2,11 @@ import { SyncLoader } from 'react-spinners';
 import { AiFillInfoCircle } from 'react-icons/ai';
 import { getWithinSevenDays } from '@utils/formatTime';
 import ShowWithinSevenDays from '@components/ShowWithinSevenDays';
-import { useState } from 'react';
 import UserNotiCard from './UserNotiCard';
 import useGetUserAlarm from '../hooks/useGetUserAlarm';
 
 const UserNotiList = () => {
   const { data: userAlarmList, isLoading } = useGetUserAlarm();
-  const [isLabel, setIsLabel] = useState(false);
 
   const sortedNotification = userAlarmList?.sort((b, a) => {
     return +new Date(a.createdAt) - +new Date(b.createdAt);
@@ -23,16 +21,23 @@ const UserNotiList = () => {
             3달이 경과된 알림은 자동 삭제처리됩니다.
           </div>
           <hr className='mx-[22.5px] w-custom border-[0.5px] border-dashed' />
-          {sortedNotification.map((item) => {
+
+          {sortedNotification.map((item, index) => {
+            const prevItem = sortedNotification[index - 1];
+
+            // 구분선 표시 조건
+            const showDivider =
+              prevItem &&
+              getWithinSevenDays(prevItem.createdAt) &&
+              !getWithinSevenDays(item.createdAt);
+
             return (
               <>
+                {showDivider && <ShowWithinSevenDays label='최근 7일' />}
                 <UserNotiCard
                   key={item.memberalrimId}
                   item={item}
                 />
-                {!isLabel && getWithinSevenDays(item.createdAt) && (
-                  <ShowWithinSevenDays label='최근 7일' />
-                )}
               </>
             );
           })}

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -9,7 +9,6 @@ interface NotificationState {
   connect: () => void;
   disconnect: () => void;
   state: boolean;
-  activeNoti: boolean;
 }
 
 const EventSource = EventSourcePolyfill || NativeEventSource;
@@ -60,8 +59,6 @@ const useNotificationStore = create<NotificationState>((set) => ({
           newMessage.notificationType === 'REVIEW_CREATED'
             ? '새 리뷰가 등록되었습니다.'
             : '새로운 예약이 등록되었습니다.';
-
-        set(() => ({ activeNoti: true }));
 
         set((state) => {
           if (state.message === newText) {

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -82,11 +82,11 @@ export const getTimeDifference = (timeString: string) => {
 export const getWithinSevenDays = (timeString: string) => {
   const milliSeconds = +new Date() - +new Date(timeString);
   const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
-  let message = '';
+  let state = false;
 
   if (milliSeconds < SEVEN_DAYS) {
-    message = '7일 이내';
+    state = true;
   }
 
-  return message;
+  return state;
 };


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 알림 페이지에 최근 7일 이내 알림 구분선 추가

## 📝 요구 사항과 구현 내용
- 사용자, 사업자 알림페이지에 3달 지난 알림은 삭제처리된다는 문구 추가
- formatTime.ts 파일에서 7일 이내인지 판별하는 함수 반환값 boolean으로 변경
- 알림 페이지에 최근 7일 이내 알림 구분선 추가
- 실시간 알림 store파일에서 사용하지 않는 activeNoti 삭제

## 🔗 연관된 이슈
- close #153 