### PR TITLE
♻️ Refactor : 예약 내역 페이지 로딩 시간 최적화 및 reissue 요청 401 응답 로그아웃 처리

### DIFF
--- a/src/pages/ReservationListPage/components/ReservationList.tsx
+++ b/src/pages/ReservationListPage/components/ReservationList.tsx
@@ -1,83 +1,88 @@
-import { useCallback, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { SyncLoader } from 'react-spinners';
 import useGetAllMyReservations from '../hooks/useGetAllMyReservations';
 import ReservationDetailCard from './ReservationDetailCard';
 
 const ReservationList = () => {
+  const [activeTab, setActiveTab] = useState('최근 결제순');
   const { reservationList, isLoading } = useGetAllMyReservations();
-  const [activeSortButton, setActiveSortButton] = useState(false);
 
   // 최근 결제일순으로 정렬
-  const sortedReservationWithPayment = useCallback(() => {
+  const sortedReservationWithPayment = useMemo(() => {
     return [...reservationList].sort(
       (b, a) =>
         +new Date(a.reservationCreatedAt) - +new Date(b.reservationCreatedAt),
     );
   }, [reservationList]);
 
-  const sortedWithPayment = sortedReservationWithPayment();
-
   // 예약일순으로 정렬
-  const sortedReservationWithDate = useCallback(() => {
+  const sortedReservationWithDate = useMemo(() => {
     return [...reservationList].sort(
       (b, a) => +new Date(a.startTime) - +new Date(b.startTime),
     );
   }, [reservationList]);
 
-  const sortedWithDate = sortedReservationWithDate();
+  if (isLoading) {
+    return (
+      <div className='flex h-[300px] w-full items-center justify-center'>
+        <SyncLoader color='#50BEAD' />
+      </div>
+    );
+  }
+
+  if (!reservationList || reservationList.length === 0) {
+    return (
+      <div className='mt-[47px] w-[375px] text-center text-[14px] font-normal text-subfont'>
+        예약 내역이 없습니다.
+      </div>
+    );
+  }
 
   return (
     <>
-      {reservationList && reservationList.length > 0 ? (
-        <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
-          <div className='mx-auto mt-5 flex w-custom justify-end gap-2 text-[13px]'>
-            <button
-              type='button'
-              className={!activeSortButton ? 'text-focusColor' : 'text-subfont'}
-              onClick={() => setActiveSortButton(!activeSortButton)}
-            >
-              최근 결제순
-            </button>
-            <span>|</span>
-            <button
-              type='button'
-              className={activeSortButton ? 'text-focusColor' : 'text-subfont'}
-              onClick={() => setActiveSortButton(!activeSortButton)}
-            >
-              예약일순
-            </button>
-          </div>
-          {!activeSortButton
-            ? sortedWithPayment.map((item) => {
-                return (
-                  <ReservationDetailCard
-                    key={item.reservationId}
-                    item={item}
-                  />
-                );
-              })
-            : sortedWithDate.map((item) => {
-                return (
-                  <ReservationDetailCard
-                    key={item.reservationId}
-                    item={item}
-                  />
-                );
-              })}
+      <div className='mt-[6px] flex w-[375px] flex-col justify-center pb-24'>
+        <div className='mx-auto mt-5 flex w-custom justify-end gap-2 text-[13px]'>
+          <button
+            type='button'
+            className={
+              activeTab === '최근 결제순' ? 'text-focusColor' : 'text-subfont'
+            }
+            onClick={() => setActiveTab('최근 결제순')}
+          >
+            최근 결제순
+          </button>
+          <span>|</span>
+          <button
+            type='button'
+            className={
+              activeTab === '예약일순' ? 'text-focusColor' : 'text-subfont'
+            }
+            onClick={() => setActiveTab('예약일순')}
+          >
+            예약일순
+          </button>
         </div>
-      ) : (
-        <>
-          {isLoading ? (
-            <div className='flex h-[300px] w-full items-center justify-center'>
-              <SyncLoader color='#50BEAD' />
-            </div>
-          ) : (
-            <div className='mt-[47px] w-[375px] text-center text-[14px] font-normal text-subfont'>
-              예약 내역이 없습니다.
-            </div>
-          )}
-        </>
-      )}
+
+        {activeTab === '최근 결제순' &&
+          sortedReservationWithPayment.map((item) => {
+            return (
+              <ReservationDetailCard
+                key={item.reservationId}
+                item={item}
+              />
+            );
+          })}
+
+        {activeTab === '예약일순' &&
+          sortedReservationWithDate.map((item) => {
+            return (
+              <ReservationDetailCard
+                key={item.reservationId}
+                item={item}
+              />
+            );
+          })}
+      </div>
     </>
   );
 };

--- a/src/pages/ReservationListPage/hooks/useGetAllMyReservations.ts
+++ b/src/pages/ReservationListPage/hooks/useGetAllMyReservations.ts
@@ -1,17 +1,22 @@
 import { getAllReservation } from '@apis/reservation';
 import { useQuery } from '@tanstack/react-query';
+import { Reservation } from '@typings/types';
 
 // 모든 예약 정보 불러오기
 const useGetAllMyReservations = () => {
   const { data, isLoading } = useQuery({
     queryKey: ['myReservationList'],
     queryFn: async () => {
+      let reservationData: Reservation[] = [];
       const reservationList = await getAllReservation();
-      const filteredReservation = reservationList.filter(
-        (item) => item.state !== 'ON_HOLD' && item.state !== 'PAYMENT_FAIL',
-      );
 
-      return filteredReservation;
+      if (reservationList) {
+        reservationData = reservationList.filter(
+          (item) => item.state !== 'ON_HOLD' && item.state !== 'PAYMENT_FAIL',
+        );
+      }
+
+      return reservationData;
     },
   });
 


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 예약 내역 페이지에서 데이터 없을 경우 로딩 시간 최적화 및 reissue 요청으로 401 응답이 오면 로그아웃 처리

## 📝 요구 사항과 구현 내용
- 예약 내역 페이지에서 데이터 없을 경우 로딩이 너무 오래 걸려서 api 호출하는 훅 코드 변경
- 예약 내역 페이지에서 정렬된 리스트를 useCallback말고 useMemo 사용해서 저장
- reissue 요청의 응답으로 401이 올 경우 로그아웃되도록 처리

## 💬 PR 포인트 & 궁금한 점
- useCallback말고 useMemo 사용한 이유가 함수보다는 데이터 정렬값이 필요하다는 판단 하에서였는데, 이게 맞는 선택인지 헷갈려서 질문합니다 은수님 생각은 어떠신가요....??  