### PR TITLE
♻️ Refactor : 맞춤형 추천 서버 안될 시 재요청 막도록 개선

### DIFF
--- a/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
+++ b/src/pages/MainPage/hooks/useGetWorkplaceData.tsx
@@ -6,6 +6,7 @@ import {
   MapPosition,
   NowPosition,
 } from '@typings/types';
+import { AxiosError } from 'axios';
 
 export const useGetWorkplaceData = (
   nowPosition: NowPosition,
@@ -31,10 +32,20 @@ export const useGetRecommendData = (
   isUser: boolean,
   activeTab: string,
 ) => {
-  const { data, isLoading, isError } = useQuery<GetPositionWorkPlaceData[]>({
+  const { data, isLoading, isError } = useQuery<
+    GetPositionWorkPlaceData[],
+    AxiosError
+  >({
     queryKey: ['recommendWorkPlace', isLogin, isUser],
     queryFn: () => getRecommendWorkPlace(),
     enabled: isLogin && isUser && activeTab !== '주변 스터디룸',
+    retry: (failureCount, error: AxiosError) => {
+      // 503 에러 발생 시 재요청 금지
+      if (error.response?.status === 503) {
+        return false;
+      }
+      return failureCount < 3;
+    },
   });
 
   return {


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 맞춤형 추천 서버 안될 시 재요청 막도록 개선

## 📝 요구 사항과 구현 내용
- 에러가 503일 경우 재요청 금지

## ✅ 피드백 반영사항
- 맞춤형 추천 서버가 안열리면 요청이 3번 가서 에러 알림이 3번이나 울리는 문제 해결했습니다
